### PR TITLE
add 'install -d' for prepare dirs (ensure that dirs exists)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,14 @@ all: $(TARGETS)
 experimental: $(EXPERIMENTAL_TARGETS)
 
 install: all
+	$(INSTALL) -d $(PREFIX)/bin
 	$(INSTALL) -oroot -groot -m755 $(TARGETS) $(PREFIX)/bin
+	$(INSTALL) -d $(PREFIX)/share/man/man1
 	$(INSTALL) -oroot -groot -m644 f3read.1 $(PREFIX)/share/man/man1
 	$(LN) -sf f3read.1 $(PREFIX)/share/man/man1/f3write.1
 
 install-experimental: experimental
+	$(INSTALL) -d $(PREFIX)/bin
 	$(INSTALL) -oroot -groot -m755 $(EXPERIMENTAL_TARGETS) $(PREFIX)/bin
 
 f3write: utils.o f3write.o


### PR DESCRIPTION
this fix is required for creating packages under chroot/etc
for example see
https://github.com/bor/gentoo-overlay/tree/master/sys-block/f3