### PR TITLE
man page: Add reference to F3 web page

### DIFF
--- a/f3read.1
+++ b/f3read.1
@@ -44,6 +44,10 @@ To read this flash drive:
       $ f3read /media/TEST
 .fam T
 .fi
+.SH SEE ALSO
+For detailed information about the F3 tools, see:
+.PP
+http://oss.digirati.com.br/f3/
 .SH AUTHOR
 F3 was written by Michel Machado <michel@digirati.com.br>.
 This manual page was first written by Joao Eriberto Mota Filho <eriberto@eriberto.pro.br>.


### PR DESCRIPTION
The man page for the f3read/f3write tools is rather brief. I think it should contain a reference to the web page for more detailed information.