### PR TITLE
Adjust Makefile to use argp for non-GNU systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC ?= gcc
-CFLAGS += -std=c99 -Wall -Wextra -pedantic -MMD -ggdb
+CFLAGS += -std=c99 -Wall -Wextra -pedantic -MMD -ggdb -I/usr/local/include
+LDFLAGS += -L/usr/local/lib -largp
 
 TARGETS = f3write f3read
 EXTRA_TARGETS = f3probe f3brew f3fix


### PR DESCRIPTION
This fixes builds on OS X, if argp-standalone is installed (#42) but also does not break the build (for me at least) on a GNU/Linux system *without* argp installed (that is: adding linker and include paths to /usr/local is benign on those systems, and -largp works with GNU libc)