### PR TITLE
fix starting time of reading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,15 @@ all: $(TARGETS)
 extra: $(EXTRA_TARGETS)
 
 install: all
-	$(INSTALL) -d $(PREFIX)/bin
-	$(INSTALL) -oroot -groot -m755 $(TARGETS) $(PREFIX)/bin
-	$(INSTALL) -d $(PREFIX)/share/man/man1
-	$(INSTALL) -oroot -groot -m644 f3read.1 $(PREFIX)/share/man/man1
-	$(LN) -sf f3read.1 $(PREFIX)/share/man/man1/f3write.1
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -oroot -groot -m755 $(TARGETS) $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/man/man1
+	$(INSTALL) -oroot -groot -m644 f3read.1 $(DESTDIR)$(PREFIX)/share/man/man1
+	$(LN) -sf f3read.1 $(DESTDIR)$(PREFIX)/share/man/man1/f3write.1
 
 install-extra: extra
-	$(INSTALL) -d $(PREFIX)/bin
-	$(INSTALL) -oroot -groot -m755 $(EXTRA_TARGETS) $(PREFIX)/bin
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -oroot -groot -m755 $(EXTRA_TARGETS) $(DESTDIR)$(PREFIX)/bin
 
 f3write: utils.o f3write.o
 	$(CC) -o $@ $^ $(LDFLAGS) -lm

--- a/f3read.c
+++ b/f3read.c
@@ -134,7 +134,7 @@ static void validate_file(const char *path, int number,
 	int final_errno;
 	struct timeval t1, t2;
 	/* Progress time. */
-	struct timeval pt1 = { .tv_sec = -1000, .tv_usec = 0 };
+	struct timeval pt1;
 
 	*ptr_ok = *ptr_corrupted = *ptr_changed = *ptr_overwritten = 0;
 
@@ -164,6 +164,8 @@ static void validate_file(const char *path, int number,
 
 	/* Obtain initial time. */
 	assert(!gettimeofday(&t1, NULL));
+	pt1 = t1;
+	pt1.tv_sec -= 1000;
 	/* Help the kernel to help us. */
 	assert(!posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL));
 


### PR DESCRIPTION
f3read did not show any progress line this morning (really, yesterday it did!). I believe the problem is with the initial value of pt1, which is now so far from the current time to make the difference wrap and become negative. At least, this is the case in an x86-32. The solution is to copy the current time to pt1, decreasing it by 1000 seconds to make sure an initial status line is printed.

I also realized that the Makefile is missing the DESTDIR variable, and added it.