### PR TITLE
Add ARGP to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ PREFIX = /usr/local
 INSTALL = install
 LN = ln
 
+ARGP = /usr/local
+
+CFLAGS += -I$(ARGP)/include
+LDFLAGS += -L$(ARGP)/lib -largp
+
 all: $(TARGETS)
 extra: $(EXTRA_TARGETS)
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ INSTALL = install
 LN = ln
 
 ARGP = /usr/local
-
 CFLAGS += -I$(ARGP)/include
 LDFLAGS += -L$(ARGP)/lib -largp
 


### PR DESCRIPTION
Allow the prefix of argp-standalone to be passed to `make` so that the
CFLAGS and LDFLAGS for argp-standalone don't have to be set manually.