### PR TITLE
Set argp-standalone flags per-OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,14 @@ PREFIX = /usr/local
 INSTALL = install
 LN = ln
 
-# ATTENTION: You may need to enable the following lines to compile F3
-#            on your platform.
-#ARGP = /usr/local
-#CFLAGS += -I$(ARGP)/include
-#LDFLAGS += -L$(ARGP)/lib -largp
+ifndef OS
+	OS = $(shell uname -s)
+endif
+ifneq ($(OS), Linux)
+	ARGP = /usr/local
+	CFLAGS += -I$(ARGP)/include
+	LDFLAGS += -L$(ARGP)/lib -largp
+endif
 
 all: $(TARGETS)
 extra: $(EXTRA_TARGETS)

--- a/README.rst
+++ b/README.rst
@@ -154,22 +154,16 @@ for details.
    See https://trac.macports.org/browser/trunk/dports/sysutils/f3/Portfile
    for more information.
 
-4) Set compilation flags. These following environment variables are used
-   in the Makefile to locate the argp library:
-
-   HomeBrew::
-
-     export CFLAGS="$CFLAGS -I/usr/local/include/"
-     export LDFLAGS="$LDFLAGS -L/usr/local/lib/ -largp"
-
-   MacPorts::
-
-     export CFLAGS="$CFLAGS -I/opt/local/include/"
-     export LDFLAGS="$LDFLAGS -L/opt/local/lib/ -largp"
-
 5) Build F3::
 
+   When using Homebrew, you can just run::
+
        make
+
+   When using MacPorts, you will need to pass the location where MacPorts
+   installed argp-standalone::
+
+       make ARGP=/opt/local
 
 The extra applications for Linux
 --------------------------------

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ for details.
    See https://trac.macports.org/browser/trunk/dports/sysutils/f3/Portfile
    for more information.
 
-5) Build F3::
+4) Build F3::
 
    When using Homebrew, you can just run::
 


### PR DESCRIPTION
This is a followup to #67.

As discussed in https://github.com/AltraMayor/f3/pull/67#issuecomment-353637661, this only sets up the argp flags if the detected OS isn't Linux. That should ensure it automatically picks up the flags on other OSs without breaking the Linux build.

This also makes the README changes requested in https://github.com/AltraMayor/f3/pull/67#issuecomment-353645335. For Homebrew I suggest just running `make`, since the default `ARGP` value of `/usr/local` is also where Homebrew will install it by default.