### PR TITLE
HTTPS-ify & fix links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ for details.
 
      /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-   See http://brew.sh/ for details.
+   See https://brew.sh/ for details.
 
    MacPorts: https://www.macports.org/install.php
 

--- a/doc/history.rst
+++ b/doc/history.rst
@@ -34,7 +34,7 @@ Change log
 
 Starting at version 2.0, F3 supports the platform Mac. Mac users may
 want to check out Thijs Kuipers'
-`page <http://www.broes.nl/2012/08/verify-the-integrity-of-a-flash-sd-card-on-a-mac/>`__
+`page <https://www.broes.nl/2012/08/verify-the-integrity-of-a-flash-sd-card-on-a-mac/>`__
 for help.
 
 Starting at version 3.0, F3 supports the platform Windows/Cygwin, and
@@ -53,7 +53,7 @@ Starting at version 6.0, F3 includes ``f3brew`` as experimental, and for
 Linux only. Linux users may want to check out Vasiliy Kaygorodov's
 `page <https://serverissues.com/blog/2015/12/12/finding-out-chinese-flash-disk-slash-sdhc-card-real-size/>`__
 or Ahmed Essam's
-`page <http://ahmedspace.com/linux-how-to-fix-a-flash-memory-corrupting-files/>`__
+`page <https://ahmedspace.com/how-to-recover-a-corrupted-flash-memory-using-f3-tools-under-linux/>`__
 for help.
 
 Starting at version 7.0, ``f3probe``, ``f3fix``, and ``f3brew`` are stable.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -486,14 +486,14 @@ because it is robust against all counterfeits. However, as drives'
 capacity grows, the time to test these newer drives becomes so painful
 that one rarely runs H2testw's algorithm on a whole drive, but only a
 fraction of it. See question "Why test only 25% or 32GB?" on `this
-FAQ <http://www.ebay.com/gds/All-About-Fake-Flash-Drives-2013-/10000000177553258/g.html>`__
+FAQ <https://web.archive.org/web/20180318154936/https://www.ebay.com/gds/All-About-Fake-Flash-Drives-2013-/10000000177553258/g.html>`__
 for a defense of this approach.
 
 The problem with this approach is that drives are still getting bigger,
 and counterfeiters may, in the future, be able to profit with fake drives
 whose real capacity are large enough to fool these partial tests. This
 problem is not new. For example, Steve Si implemented
-`FakeFlashTest.exe <http://www.rmprepusb.com/tutorials/-fake-usb-flash-memory-drives>`__,
+`FakeFlashTest.exe <https://www.rmprepusb.com/tutorials/-fake-usb-flash-memory-drives>`__,
 which has successfully reduced the amount of time to test drives, and is
 still able to give a good estimate of the real size of fake drives. Yet,
 `FakeFlashTest.exe's


### PR DESCRIPTION
Several of the HTTP links are now available over HTTPS, and the documentation should link directly to the secure version of the referenced page.

Along the way, a couple of broken links were updated. The eBay guide to fake flash, in particular, was nowhere to be found (that I could see) except the Internet Archive, so I pointed the link in F3's documentation there for user convenience.