### PR TITLE
libdevs: bring back missing ‘const’ specifier

### DIFF
--- a/libdevs.c
+++ b/libdevs.c
@@ -23,7 +23,7 @@
 #include "libutils.h"
 #include "libdevs.h"
 
-static const char *ftype_to_name[FKTY_MAX] = {
+static const char * const ftype_to_name[FKTY_MAX] = {
 	[FKTY_GOOD]		= "good",
 	[FKTY_BAD]		= "bad",
 	[FKTY_LIMBO]		= "limbo",


### PR DESCRIPTION
Commit 7ff9fad37a32 ("libdevs: fix compiler warning") fixed the warning
by removing duplicate ‘const’ specifier.
The original intent of two `const` specifiers, was most likely to make
non-mutable both: the `ftype_to_name` array itself and its elements,
so bring back the second `const`, but in the correct place this time,
i.e. after ‘*‘.