### PR TITLE
Readme: Add Fedora dependency install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,6 +206,10 @@ can install these libraries with the following command::
 
     sudo apt-get install libudev1 libudev-dev libparted0-dev
 
+On Fedora, you can install these libraries with the following command::
+
+    sudo dnf install systemd-devel parted-devel
+
 Compile the extra applications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I've verified the dependencies within a container:

```
podman run --rm -it fedora:latest bash
# make
dnf install make gcc 

# make extra
dnf install systemd-devel parted-devel
```