### PR TITLE
Correct overflow protection

### DIFF
--- a/libprobe.c
+++ b/libprobe.c
@@ -690,7 +690,7 @@ uint64_t probe_device_max_blocks(struct device *dev)
 	/* Make sure that there is no overflow in the formula below.
 	 * The number 10 is arbitrary here, that is, it's not tight.
 	 */
-	assert(MAX_N_BLOCK_ORDER < sizeof(int) - 10);
+	assert(MAX_N_BLOCK_ORDER < 8*sizeof(int) - 10);
 
 	return
 		/* find_cache_size() */


### PR DESCRIPTION
`sizeof()` returns the number of bytes, not bits, and since this is as an unsigned type and the value typically less than 10 the assertion currently does not fail but also fails to detect problems when `MAX_N_BLOCK_ORDER` is too big as the comparison is with the the very big number resulting from an unsigned overflow, typically 2^32-2.