### PR TITLE
Add portability to Bash Program location

### DIFF
--- a/f3write.h2w
+++ b/f3write.h2w
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 $(dirname $0)/f3write "$@" || exit 1
 

--- a/log-f3wr
+++ b/log-f3wr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 LOG=$1
 $(dirname $0)/f3write "${@:2}" 2>&1 | tee -a "${LOG}" && \
 echo -e "\n\n" >> "${LOG}" && \


### PR DESCRIPTION
Shebang Portability.
Add portability to Bash Program location.
Some OSX users like me change the default bash env (``/bin/bash``) to ``/usr/local/bin/bash``
 