### PR TITLE
Change libparted library name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,9 @@ can install these libraries with the following command::
 
     sudo apt-get install libudev1 libudev-dev libparted-dev
 
+If you running a version of Ubuntu before 20.04.1, replace the package `libparted-dev`
+on the command line above with `libparted0-dev`.
+
 On Fedora, you can install these libraries with the following command::
 
     sudo dnf install systemd-devel parted-devel

--- a/README.rst
+++ b/README.rst
@@ -277,7 +277,7 @@ f3probe and f3brew require version 1 of the library libudev, and f3fix
 requires version 0 of the library libparted to compile. On Ubuntu, you
 can install these libraries with the following command::
 
-    sudo apt-get install libudev1 libudev-dev libparted0-dev
+    sudo apt-get install libudev1 libudev-dev libparted-dev
 
 On Fedora, you can install these libraries with the following command::
 

--- a/README.rst
+++ b/README.rst
@@ -279,7 +279,7 @@ can install these libraries with the following command::
 
     sudo apt-get install libudev1 libudev-dev libparted-dev
 
-If you running a version of Ubuntu before 20.04.1, replace the package `libparted-dev`
+If you are running a version of Ubuntu before 20.04.1, replace the package `libparted-dev`
 on the command line above with `libparted0-dev`.
 
 On Fedora, you can install these libraries with the following command::


### PR DESCRIPTION
On Ubuntu 20.04.1 LTS, the name of the library is libparted-dev