### PR TITLE
Quick Fix | Replaces linking from releases to tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Download and Compile
 --------------------
 
 The files of the stable version of F3 are
-`here <https://github.com/AltraMayor/f3/releases>`__. The
+`here <https://github.com/AltraMayor/f3/tags>`__. The
 following command uncompresses the files::
 
     $ unzip f3-8.0.zip


### PR DESCRIPTION
This PR replaces a link name to solve the following problem: when the user clicks to download the zipped package, the link follows to an empty releases page.