### PR TITLE
Docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gcc \
         less \
-        libparted0-dev \
+        libparted-dev \
         libudev1 \
         libudev-dev \
         make \

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ endif
 all: $(TARGETS)
 extra: $(EXTRA_TARGETS)
 
+docker:
+	docker build -f Dockerfile -t f3:latest .
+
 install: all
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -m755 $(TARGETS) $(DESTDIR)$(PREFIX)/bin

--- a/README.rst
+++ b/README.rst
@@ -202,8 +202,20 @@ For example, to probe a drive mounted at /dev/sdX::
 Optionally, you can also build your own container *if* you don't want to use the
 pre-built image.  From this directory, run::
 
+    make docker
+
+or::
+
     docker build -t f3:latest .
+
+
+To run f3 commands using your newly built Docker image::
+
     docker run -it --rm --device <device> f3:latest <f3-command> [<f3-options>] <device>
+
+    docker run -it --rm --device /dev/sdX f3:latest f3probe --destructive --time-ops /dev/sdX
+    docker run -it --rm -v /path/to/mounted/device:/mnt/ f3:latest f3write /mnt/
+    docker run -it --rm -v /path/to/mounted/device:/mnt/ f3:latest f3read /mnt/
 
 Drive Permissions / Passthrough
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Updates Docker base image from Ubuntu 18.04 (now EOL) to Ubuntu 22.04 (current LTS release)
- Adds Makefile target to build Docker image. Especially useful since recommended Docker image `peron/f3` is out of date (as of May 2023)
- Updates README self-built Docker image usage instructions