### PR TITLE
fix obsolete link to the brew formula

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ for details.
 
        brew install argp-standalone
 
-   See http://brewformulas.org/ArgpStandalone and
+   See https://formulae.brew.sh/formula/argp-standalone and
    https://www.freshports.org/devel/argp-standalone/ for more
    information.
 


### PR DESCRIPTION
Previous domain has been replaced by a pharmaceutical website since 2020 https://web.archive.org/web/20200415000000*/http://brewformulas.org/