### PR TITLE
support building f3write and f3read on Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ ifndef OS
 endif
 ifneq ($(OS), Linux)
 	ARGP = /usr/local
+	ifeq ($(OS), Darwin)
+		ifneq ($(shell command -v brew),)
+			ARGP = $(shell brew --prefix)
+		endif
+	endif
 	CFLAGS += -I$(ARGP)/include
 	LDFLAGS += -L$(ARGP)/lib -largp
 endif


### PR DESCRIPTION
Homebrew on Apple Silicon uses a different include path. See first paragraphs of the documentation:
https://docs.brew.sh/Installation

It's:
- `/usr/local` on Intel
- `/opt/homebrew` on Apple Silicon