### PR TITLE
Add the compiled binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ cscope.out
 *~
 
 doc/_build
+
+f3brew
+f3fix
+f3probe
+f3read
+f3write


### PR DESCRIPTION
This PR adds the compiled binaries to the .gitignore file.

While viewing the repository in VSCodium, I noticed that locally compiled binaries were not ignored by Git.

The following locally built binaries are now ignored:
```text
f3brew
f3fix
f3probe
f3read
f3write
```