### PR TITLE
f3probe: I/O speeds

### DIFF
--- a/f3brew.c
+++ b/f3brew.c
@@ -321,8 +321,8 @@ static void test_write_blocks(struct device *dev,
 	const uint64_t total_size = (last_block - first_block + 1) << block_order;
 	struct flow fw;
 
-	printf("Writing blocks from 0x%" PRIx64 " to 0x%" PRIx64 "... ",
-		first_block, last_block);
+	printf("Writing block%s from 0x%" PRIx64 " to 0x%" PRIx64 "... ",
+		first_block != last_block ? "s" : "", first_block, last_block);
 	fflush(stdout);
 
 	init_flow(&fw, block_size, total_size, max_write_rate,
@@ -494,15 +494,15 @@ static void test_read_blocks(struct device *dev,
 	struct flow fw;
 	struct block_stats stats = { 0, 0, 0, 0 };
 
-	printf("Reading blocks from 0x%" PRIx64 " to 0x%" PRIx64 ":\n",
-		first_block, last_block);
+	printf("Reading block%s from 0x%" PRIx64 " to 0x%" PRIx64 ":\n",
+		first_block != last_block ? "s" : "", first_block, last_block);
 
 	init_flow(&fw, block_size, total_size, max_read_rate,
 		show_progress ? printf_flush_cb : dummy_cb, 0, NULL);
 
 	read_blocks(dev, &fw, first_block, last_block, &stats);
 
-	print_stats(&stats, block_size, "blocks");
+	print_stats(&stats, block_size, "block");
 	print_avg_seq_speed(&fw, "read", false);
 	printf("\n");
 }
@@ -530,6 +530,7 @@ int main(int argc, char **argv)
 		.show_progress	= isatty(STDOUT_FILENO),
 	};
 	struct device *dev;
+	int block_order;
 	uint64_t very_last_block;
 
 	/* Read parameters. */
@@ -546,10 +547,11 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	printf("Physical block size: 2^%i Bytes\n\n", dev_get_block_order(dev));
+	block_order = dev_get_block_order(dev);
+	printf("Physical block size: 2^%i Byte%s\n\n",
+		block_order, block_order != 0 ? "s" : "");
 
-	very_last_block =
-		(dev_get_size_byte(dev) >> dev_get_block_order(dev)) - 1;
+	very_last_block = (dev_get_size_byte(dev) >> block_order) - 1;
 	if (args.first_block > very_last_block)
 		args.first_block = very_last_block;
 	if (args.last_block > very_last_block)

--- a/f3brew.c
+++ b/f3brew.c
@@ -320,7 +320,6 @@ static void test_write_blocks(struct device *dev,
 	const int block_order = dev_get_block_order(dev);
 	const uint64_t total_size = (last_block - first_block + 1) << block_order;
 	struct flow fw;
-	struct timeval t1, t2;
 
 	printf("Writing blocks from 0x%" PRIx64 " to 0x%" PRIx64 "... ",
 		first_block, last_block);
@@ -329,12 +328,10 @@ static void test_write_blocks(struct device *dev,
 	init_flow(&fw, block_size, total_size, max_write_rate,
 		show_progress ? printf_flush_cb : dummy_cb, 0, NULL);
 
-	assert(!gettimeofday(&t1, NULL));
 	write_blocks(dev, &fw, first_block, last_block);
-	assert(!gettimeofday(&t2, NULL));
 
 	printf("Done\n");
-	print_measured_speed(&fw, &t1, &t2, "writing");
+	print_avg_seq_speed(&fw, "write", false);
 	printf("\n");
 }
 
@@ -495,7 +492,6 @@ static void test_read_blocks(struct device *dev,
 	const int block_order = dev_get_block_order(dev);
 	const uint64_t total_size = (last_block - first_block + 1) << block_order;
 	struct flow fw;
-	struct timeval t1, t2;
 	struct block_stats stats = { 0, 0, 0, 0 };
 
 	printf("Reading blocks from 0x%" PRIx64 " to 0x%" PRIx64 ":\n",
@@ -504,12 +500,10 @@ static void test_read_blocks(struct device *dev,
 	init_flow(&fw, block_size, total_size, max_read_rate,
 		show_progress ? printf_flush_cb : dummy_cb, 0, NULL);
 
-	assert(!gettimeofday(&t1, NULL));
 	read_blocks(dev, &fw, first_block, last_block, &stats);
-	assert(!gettimeofday(&t2, NULL));
 
 	print_stats(&stats, block_size, "blocks");
-	print_measured_speed(&fw, &t1, &t2, "reading");
+	print_avg_seq_speed(&fw, "read", false);
 	printf("\n");
 }
 

--- a/f3probe.c
+++ b/f3probe.c
@@ -347,10 +347,10 @@ static inline void report_cache(const char *prefix, uint64_t cache_size_block,
 		block_order);
 }
 
-static inline void report_io_speed(const char *prefix, uint64_t blocks,
+static inline void report_speed(const char *prefix, uint64_t blocks,
 	uint64_t time_ns, int block_order)
 {
-	report_probed_io_speed(0, printf_cb, prefix, blocks, time_ns,
+	report_io_speed(0, printf_cb, prefix, blocks, "block", time_ns,
 		block_order);
 }
 
@@ -505,13 +505,13 @@ static int test_device(struct args *args)
 		 * because the safe device disrupts the measurements.
 		 */
 		printf("\nI/O average speeds:\n");
-		report_io_speed("\tSequential write:",
+		report_speed("\tSequential write:",
 			results.seqw_blocks, results.seqw_time_ns,
 			results.block_order);
-		report_io_speed("\t    Random write:",
+		report_speed("\t    Random write:",
 			results.randw_blocks, results.randw_time_ns,
 			results.block_order);
-		report_io_speed("\t     Random read:",
+		report_speed("\t     Random read:",
 			results.randr_blocks, results.randr_time_ns,
 			results.block_order);
 	}

--- a/f3probe.c
+++ b/f3probe.c
@@ -343,7 +343,15 @@ static inline void report_order(const char *prefix, int order)
 static inline void report_cache(const char *prefix, uint64_t cache_size_block,
 	int block_order)
 {
-	report_probed_cache(0, printf_cb, prefix, cache_size_block, block_order);
+	report_probed_cache(0, printf_cb, prefix, cache_size_block,
+		block_order);
+}
+
+static inline void report_io_speed(const char *prefix, uint64_t blocks,
+	uint64_t time_ns, int block_order)
+{
+	report_probed_io_speed(0, printf_cb, prefix, blocks, time_ns,
+		block_order);
 }
 
 static void report_probe_time(const char *prefix, uint64_t usec)
@@ -491,6 +499,23 @@ static int test_device(struct args *args)
 	 report_cache("\tApproximate cache size:", results.cache_size_block,
 		results.block_order);
 	 report_order("\t   Physical block size:", results.block_order);
+
+	if (!args->save) {
+		/* Only report I/O speeds when flag --destructive is used
+		 * because the safe device disrupts the measurements.
+		 */
+		printf("\nI/O average speeds:\n");
+		report_io_speed("\tSequential write:",
+			results.seqw_blocks, results.seqw_time_ns,
+			results.block_order);
+		report_io_speed("\t    Random write:",
+			results.randw_blocks, results.randw_time_ns,
+			results.block_order);
+		report_io_speed("\t     Random read:",
+			results.randr_blocks, results.randr_time_ns,
+			results.block_order);
+	}
+
 	report_probe_time("\nProbe time:", diff_timeval_us(&t1, &t2));
 
 	if (args->time_ops) {

--- a/f3probe.c
+++ b/f3probe.c
@@ -287,10 +287,12 @@ static int unit_test(const char *filename)
 		/* Report */
 		printf("Test %i\t\ttype/real size/fake size/module/cache size/block size\n",
 			i + 1);
-		printf("\t\t%s/%.2f %s/%.2f %s/2^%i Byte/%.2f %s/2^%i Byte\n",
+		printf("\t\t%s/%.2f %s/%.2f %s/2^%i Byte%s/%.2f %s/2^%i Byte%s\n",
 			fake_type_to_name(origin_type),
 			f_real, unit_real, f_fake, unit_fake, item->wrap,
-			f_cache, unit_cache, item->block_order);
+			item->wrap != 0 ? "s" : "",
+			f_cache, unit_cache, item->block_order,
+			item->block_order != 0 ? "s" : "");
 		if (results.real_size_byte == item->real_size_byte &&
 			results.announced_size_byte == item->fake_size_byte &&
 			results.wrap == item->wrap &&
@@ -301,7 +303,8 @@ static int unit_test(const char *filename)
 				results.block_order) &&
 			results.block_order == item->block_order) {
 			success++;
-			printf("\t\tPerfect!\tMax # of written blocks: %i\n\n",
+			printf("\t\tPerfect!\tMax # of written block%s: %i\n\n",
+				max_written_blocks != 1 ? "s" : "",
 				max_written_blocks);
 		} else {
 			double ret_f_real = results.real_size_byte;
@@ -311,12 +314,14 @@ static int unit_test(const char *filename)
 			const char *ret_unit_real = adjust_unit(&ret_f_real);
 			const char *ret_unit_fake = adjust_unit(&ret_f_fake);
 			const char *ret_unit_cache = adjust_unit(&ret_f_cache);
-			printf("\tError\t%s/%.2f %s/%.2f %s/2^%i Byte/%.2f %s/2^%i Byte\n\n",
+			printf("\tError\t%s/%.2f %s/%.2f %s/2^%i Byte%s/%.2f %s/2^%i Byte%s\n\n",
 				fake_type_to_name(fake_type),
 				ret_f_real, ret_unit_real,
 				ret_f_fake, ret_unit_fake, results.wrap,
+				results.wrap != 0 ? "s" : "",
 				ret_f_cache, ret_unit_cache,
-				results.block_order);
+				results.block_order,
+				results.block_order != 0 ? "s" : "");
 		}
 	}
 

--- a/f3probe.c
+++ b/f3probe.c
@@ -348,15 +348,15 @@ static inline void report_cache(const char *prefix, uint64_t cache_size_block,
 static void report_probe_time(const char *prefix, uint64_t usec)
 {
 	char str[TIME_STR_SIZE];
-	usec_to_str(usec, str);
+	nsec_to_str(usec * 1000ULL, str);
 	printf("%s %s\n", prefix, str);
 }
 
 static void report_ops(const char *op, uint64_t count, uint64_t time_us)
 {
 	char str1[TIME_STR_SIZE], str2[TIME_STR_SIZE];
-	usec_to_str(time_us, str1);
-	usec_to_str(count > 0 ? time_us / count : 0, str2);
+	nsec_to_str(time_us * 1000ULL, str1);
+	nsec_to_str(count > 0 ? (time_us * 1000ULL) / count : 0, str2);
 	printf("%10s: %s / %" PRIu64 " = %s\n", op, str1, count, str2);
 }
 

--- a/f3probe.c
+++ b/f3probe.c
@@ -56,6 +56,10 @@ static struct argp_option options[] = {
 		"Show detailed progress",		0},
 	{"show-progress",	'p',	"NUM",		0,
 		"Show progress if NUM is not zero",			0},
+	{"max-read-rate",	'r',	"KB/s",		0,
+		"Maximum read rate",					0},
+	{"max-write-rate",	'w',	"KB/s",		0,
+		"Maximum write rate",					0},
 	{ 0 }
 };
 
@@ -73,6 +77,10 @@ struct args {
 	bool		time_ops;
 	bool		verbose;
 	bool		show_progress;
+
+	/* Flow control. */
+	long		max_read_rate;
+	long		max_write_rate;
 
 	/* Geometry. */
 	uint64_t	real_size_byte;
@@ -171,6 +179,22 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 
 	case 'p':
 		args->show_progress = !!arg_to_ll_bytes(state, arg);
+		break;
+
+	case 'r':
+		ll = arg_to_ll_bytes(state, arg);
+		if (ll <= 0)
+			argp_error(state,
+				"KB/s must be greater than zero");
+		args->max_read_rate = ll;
+		break;
+
+	case 'w':
+		ll = arg_to_ll_bytes(state, arg);
+		if (ll <= 0)
+			argp_error(state,
+				"KB/s must be greater than zero");
+		args->max_write_rate = ll;
 		break;
 
 	case ARGP_KEY_INIT:
@@ -278,7 +302,7 @@ static int unit_test(const char *filename)
 			item->cache_order, item->strict_cache, false);
 		assert(dev);
 		max_written_blocks = probe_max_written_blocks(dev);
-		assert(!probe_device(dev, &results, dummy_cb, false));
+		assert(!probe_device(dev, &results, dummy_cb, false, 0, 0));
 		free_device(dev);
 		fake_type = dev_param_to_type(results.real_size_byte,
 			results.announced_size_byte, results.wrap,
@@ -427,7 +451,8 @@ static int test_device(struct args *args)
 	 */
 	assert(!probe_device(dev, &results,
 		args->verbose ? printf_flush_cb : dummy_cb,
-		args->show_progress));
+		args->show_progress,
+		args->max_read_rate, args->max_write_rate));
 	assert(!gettimeofday(&t2, NULL));
 
 	if (args->verbose) {
@@ -546,6 +571,8 @@ int main(int argc, char **argv)
 		.verbose	= false,
 		/* If stdout isn't a terminal, suppress progress. */
 		.show_progress	= isatty(STDOUT_FILENO),
+		.max_read_rate	= 0,
+		.max_write_rate = 0,
 		.real_size_byte	= 1ULL << 31,
 		.fake_size_byte	= 1ULL << 34,
 		.wrap		= 31,

--- a/f3probe.c
+++ b/f3probe.c
@@ -268,9 +268,9 @@ static int unit_test(const char *filename)
 		const char *unit_fake = adjust_unit(&f_fake);
 		const char *unit_cache = adjust_unit(&f_cache);
 
+		struct probe_results results;
 		enum fake_type fake_type;
-		uint64_t real_size_byte, announced_size_byte, cache_size_block;
-		int wrap, block_order, max_written_blocks;
+		int max_written_blocks;
 		struct device *dev;
 
 		dev = create_file_device(filename, item->real_size_byte,
@@ -278,12 +278,11 @@ static int unit_test(const char *filename)
 			item->cache_order, item->strict_cache, false);
 		assert(dev);
 		max_written_blocks = probe_max_written_blocks(dev);
-		assert(!probe_device(dev, &real_size_byte, &announced_size_byte,
-			&wrap, &cache_size_block, &block_order, dummy_cb,
-			false));
+		assert(!probe_device(dev, &results, dummy_cb, false));
 		free_device(dev);
-		fake_type = dev_param_to_type(real_size_byte,
-			announced_size_byte, wrap, block_order);
+		fake_type = dev_param_to_type(results.real_size_byte,
+			results.announced_size_byte, results.wrap,
+			results.block_order);
 
 		/* Report */
 		printf("Test %i\t\ttype/real size/fake size/module/cache size/block size\n",
@@ -292,30 +291,32 @@ static int unit_test(const char *filename)
 			fake_type_to_name(origin_type),
 			f_real, unit_real, f_fake, unit_fake, item->wrap,
 			f_cache, unit_cache, item->block_order);
-		if (real_size_byte == item->real_size_byte &&
-			announced_size_byte == item->fake_size_byte &&
-			wrap == item->wrap &&
+		if (results.real_size_byte == item->real_size_byte &&
+			results.announced_size_byte == item->fake_size_byte &&
+			results.wrap == item->wrap &&
 			/* probe_device() returns an upper bound of
 			 * the cache size.
 			 */
-			item_cache_byte <= (cache_size_block << block_order) &&
-			block_order == item->block_order) {
+			item_cache_byte <= (results.cache_size_block <<
+				results.block_order) &&
+			results.block_order == item->block_order) {
 			success++;
 			printf("\t\tPerfect!\tMax # of written blocks: %i\n\n",
 				max_written_blocks);
 		} else {
-			double ret_f_real = real_size_byte;
-			double ret_f_fake = announced_size_byte;
-			double ret_f_cache = cache_size_block << block_order;
+			double ret_f_real = results.real_size_byte;
+			double ret_f_fake = results.announced_size_byte;
+			double ret_f_cache = results.cache_size_block <<
+				results.block_order;
 			const char *ret_unit_real = adjust_unit(&ret_f_real);
 			const char *ret_unit_fake = adjust_unit(&ret_f_fake);
 			const char *ret_unit_cache = adjust_unit(&ret_f_cache);
 			printf("\tError\t%s/%.2f %s/%.2f %s/2^%i Byte/%.2f %s/2^%i Byte\n\n",
 				fake_type_to_name(fake_type),
 				ret_f_real, ret_unit_real,
-				ret_f_fake, ret_unit_fake, wrap,
+				ret_f_fake, ret_unit_fake, results.wrap,
 				ret_f_cache, ret_unit_cache,
-				block_order);
+				results.block_order);
 		}
 	}
 
@@ -363,10 +364,9 @@ static void report_ops(const char *op, uint64_t count, uint64_t time_us)
 static int test_device(struct args *args)
 {
 	struct timeval t1, t2;
+	struct probe_results results;
 	struct device *dev, *pdev, *sdev;
 	enum fake_type fake_type;
-	uint64_t real_size_byte, announced_size_byte, cache_size_block;
-	int wrap, block_order;
 	uint64_t read_count, read_time_us;
 	uint64_t write_count, write_time_us;
 	uint64_t reset_count, reset_time_us;
@@ -412,8 +412,7 @@ static int test_device(struct args *args)
 	/* XXX Have a better error handling to recover
 	 * the state of the drive.
 	 */
-	assert(!probe_device(dev, &real_size_byte, &announced_size_byte,
-		&wrap, &cache_size_block, &block_order,
+	assert(!probe_device(dev, &results,
 		args->verbose ? printf_flush_cb : dummy_cb,
 		args->show_progress));
 	assert(!gettimeofday(&t2, NULL));
@@ -433,7 +432,8 @@ static int test_device(struct args *args)
 			&write_count, &write_time_us,
 			&reset_count, &reset_time_us);
 	if (sdev) {
-		uint64_t very_last_pos = real_size_byte >> block_order;
+		uint64_t very_last_pos = results.real_size_byte >>
+			results.block_order;
 		printf("Probe finished, recovering blocks...");
 		fflush(stdout);
 		if (very_last_pos > 0) {
@@ -449,8 +449,9 @@ static int test_device(struct args *args)
 	if (args->save)
 		printf("\n");
 
-	fake_type = dev_param_to_type(real_size_byte, announced_size_byte,
-		wrap, block_order);
+	fake_type = dev_param_to_type(results.real_size_byte,
+		results.announced_size_byte, results.wrap,
+		results.block_order);
 	switch (fake_type) {
 	case FKTY_GOOD:
 		printf("Good news: The device `%s' is the real thing\n",
@@ -465,8 +466,9 @@ static int test_device(struct args *args)
 	case FKTY_LIMBO:
 	case FKTY_WRAPAROUND:
 	case FKTY_CHAIN: {
-		uint64_t last_good_sector = (real_size_byte >> SECTOR_ORDER) - 1;
-		assert(block_order >= SECTOR_ORDER);
+		uint64_t last_good_sector = (results.real_size_byte >>
+			SECTOR_ORDER) - 1;
+		assert(results.block_order >= SECTOR_ORDER);
 		printf("Bad news: The device `%s' is a counterfeit of type %s\n\n"
 			"You can \"fix\" this device using the following command:\n"
 			"f3fix --last-sec=%" PRIu64 " %s\n",
@@ -481,14 +483,14 @@ static int test_device(struct args *args)
 	}
 
 	printf("\nDevice geometry:\n");
-	  report_size("\t         *Usable* size:", real_size_byte,
-		block_order);
-	  report_size("\t        Announced size:", announced_size_byte,
-		block_order);
-	 report_order("\t                Module:", wrap);
-	 report_cache("\tApproximate cache size:", cache_size_block,
-		block_order);
-	 report_order("\t   Physical block size:", block_order);
+	  report_size("\t         *Usable* size:", results.real_size_byte,
+		results.block_order);
+	  report_size("\t        Announced size:", results.announced_size_byte,
+		results.block_order);
+	 report_order("\t                Module:", results.wrap);
+	 report_cache("\tApproximate cache size:", results.cache_size_block,
+		results.block_order);
+	 report_order("\t   Physical block size:", results.block_order);
 	report_probe_time("\nProbe time:", diff_timeval_us(&t1, &t2));
 
 	if (args->time_ops) {

--- a/f3read.c
+++ b/f3read.c
@@ -361,7 +361,7 @@ static void iterate_files(const char *path, const long *files,
 	 * in @files is important since @end_at could be very large.
 	 */
 
-	print_stats(&tot_stats, SECTOR_SIZE, "sectors");
+	print_stats(&tot_stats, SECTOR_SIZE, "sector");
 	if (or_missing_file)
 		printf("WARNING: Not all F3 files in the range %li to %li are available\n",
 			start_at + 1, number);

--- a/f3read.c
+++ b/f3read.c
@@ -322,7 +322,6 @@ static void iterate_files(const char *path, const long *files,
 	int or_missing_file = 0;
 	long number = start_at;
 	struct flow fw;
-	struct timeval t1, t2;
 
 	UNUSED(end_at);
 
@@ -331,7 +330,6 @@ static void iterate_files(const char *path, const long *files,
 	printf("                  SECTORS "
 		"     ok/corrupted/changed/overwritten\n");
 
-	assert(!gettimeofday(&t1, NULL));
 	while (*files >= 0) {
 		struct file_stats stats;
 
@@ -355,7 +353,6 @@ static void iterate_files(const char *path, const long *files,
 		and_read_all = and_read_all && stats.read_all;
 		files++;
 	}
-	assert(!gettimeofday(&t2, NULL));
 	assert(tot_size == SECTOR_SIZE *
 		(tot_stats.ok + tot_stats.bad + tot_stats.changed
 			+ tot_stats.overwritten));
@@ -372,7 +369,7 @@ static void iterate_files(const char *path, const long *files,
 		printf("WARNING: Not all data was read due to I/O error(s)\n");
 
 	/* Reading speed. */
-	print_measured_speed(&fw, &t1, &t2, "reading");
+	print_avg_seq_speed(&fw, "read", true);
 }
 
 int main(int argc, char **argv)

--- a/f3write.c
+++ b/f3write.c
@@ -182,7 +182,7 @@ static int create_and_fill_file(const char *path, long number, size_t size,
 	struct dynamic_buffer dbuf;
 
 	assert(size > 0);
-	assert(size % fw->block_size == 0);
+	assert(size % fw_get_block_size(fw) == 0);
 
 	/* Create the file. */
 	full_fn = full_fn_from_number(&filename, path, number);

--- a/f3write.c
+++ b/f3write.c
@@ -278,7 +278,6 @@ static int fill_fs(const char *path, long start_at, long end_at,
 	struct flow fw;
 	long i;
 	int has_suggested_max_write_rate = max_write_rate > 0;
-	struct timeval t1, t2;
 
 	free_space = get_freespace(path);
 	pr_freespace(free_space);
@@ -307,17 +306,15 @@ static int fill_fs(const char *path, long start_at, long end_at,
 
 	init_flow(&fw, get_block_size(path), free_space, max_write_rate,
 		progress ? printf_flush_cb : dummy_cb, 0, flush_chunk);
-	assert(!gettimeofday(&t1, NULL));
 	for (i = start_at; i <= end_at; i++)
 		if (create_and_fill_file(path, i, GIGABYTES,
 			&has_suggested_max_write_rate, &fw))
 			break;
-	assert(!gettimeofday(&t2, NULL));
 
 	/* Final report. */
 	pr_freespace(get_freespace(path));
 	/* Writing speed. */
-	print_measured_speed(&fw, &t1, &t2, "writing");
+	print_avg_seq_speed(&fw, "write", true);
 
 	return 0;
 }

--- a/libflow.c
+++ b/libflow.c
@@ -1,15 +1,16 @@
 #define _POSIX_C_SOURCE 200112L
 #define _XOPEN_SOURCE 600
 
+#include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <float.h>
 #include <assert.h>
 #include <math.h>
 #include <sys/time.h>
+#include <time.h>
 #include <string.h>
 
 #include "libflow.h"
@@ -535,39 +536,26 @@ out:
 	return ret;
 }
 
-static inline void pr_avg_speed(const char *speed_type, double speed)
+void print_avg_seq_speed(const struct flow *fw, const char *speed_type,
+	bool use_sectors)
 {
-	const char *unit = adjust_unit(&speed);
-	printf("Average %s speed: %.2f %s/s\n", speed_type, speed, unit);
-}
+	int block_order = fw_get_block_order(fw);
+	uint64_t blocks, time_ns;
+	char prefix[128];
+	int ret = snprintf(prefix, sizeof(prefix), "Average sequential %s speed:",
+		speed_type);
+	assert(ret > 0 && (size_t)ret < sizeof(prefix));
 
-static inline int64_t delay_ms(const struct timeval *t1,
-	const struct timeval *t2)
-{
-	return (int64_t)(t2->tv_sec  - t1->tv_sec)  * 1000 +
-			(t2->tv_usec - t1->tv_usec) / 1000;
-}
-
-void print_measured_speed(const struct flow *fw, const struct timeval *t1,
-	const struct timeval *t2, const char *speed_type)
-{
-	if (has_enough_measurements(fw)) {
-		pr_avg_speed(speed_type, get_avg_speed(fw));
-	} else {
-		/* If the drive is too fast for the measurements above,
-		 * try a coarse approximation of the speed.
-		 */
-		int64_t total_time_ms = delay_ms(t1, t2);
-		if (total_time_ms > 0) {
-			pr_avg_speed(speed_type,
-				get_avg_speed_given_time(fw, total_time_ms *
-					1000000ULL));
-		} else {
-			assert(strlen(speed_type) > 0);
-			printf("%c%s speed not available\n",
-				toupper(speed_type[0]), speed_type + 1);
-		}
+	fw_get_measurements(fw, &blocks, &time_ns);
+	if (use_sectors && block_order != SECTOR_ORDER) {
+		assert(block_order > SECTOR_ORDER);
+		blocks <<= block_order - SECTOR_ORDER;
+		block_order = SECTOR_ORDER;
 	}
+
+	report_io_speed(0, printf_cb, prefix, blocks,
+		use_sectors ? "sector" : "block",
+		time_ns, block_order);
 }
 
 static inline void __dbuf_free(struct dynamic_buffer *dbuf)

--- a/libflow.h
+++ b/libflow.h
@@ -77,6 +77,11 @@ void init_flow(struct flow *fw, int block_size, uint64_t total_size,
 	long max_process_rate, progress_cb cb, unsigned int indent,
 	flow_func_flush_chunk_t func_flush_chunk);
 
+static inline int fw_get_block_size(const struct flow *fw)
+{
+	return fw->block_size;
+}
+
 static inline void inc_total_size(struct flow *fw, uint64_t size)
 {
 	fw->total_size = fw->total_processed + size;
@@ -85,6 +90,13 @@ static inline void inc_total_size(struct flow *fw, uint64_t size)
 static inline void fw_set_indent(struct flow *fw, unsigned int indent)
 {
 	fw->indent = indent;
+}
+
+static inline void fw_get_measurements(const struct flow *fw,
+	uint64_t *blocks, uint64_t *time_ns)
+{
+	*blocks = fw->measured_blocks + fw->processed_blocks;
+	*time_ns = fw->measured_time_ns + fw->acc_delay_ns;
 }
 
 uint64_t get_rem_chunk_size(const struct flow *fw);

--- a/libflow.h
+++ b/libflow.h
@@ -82,6 +82,11 @@ static inline int fw_get_block_size(const struct flow *fw)
 	return fw->block_size;
 }
 
+static inline int fw_get_block_order(const struct flow *fw)
+{
+	return ilog2(fw->block_size);
+}
+
 static inline void inc_total_size(struct flow *fw, uint64_t size)
 {
 	fw->total_size = fw->total_processed + size;
@@ -106,8 +111,8 @@ int measure(int fd, struct flow *fw, long processed);
 void clear_progress(struct flow *fw);
 int end_measurement(int fd, struct flow *fw);
 
-void print_measured_speed(const struct flow *fw, const struct timeval *t1,
-	const struct timeval *t2, const char *speed_type);
+void print_avg_seq_speed(const struct flow *fw, const char *speed_type,
+	bool use_sectors);
 
 struct dynamic_buffer {
 	char   *buf;

--- a/libprobe.c
+++ b/libprobe.c
@@ -834,9 +834,8 @@ static void report_io_speed(unsigned int indent, progress_cb cb,
 		prefix, speed, unit, blocks, time_str);
 }
 
-int probe_device(struct device *dev, uint64_t *preal_size_byte,
-	uint64_t *pannounced_size_byte, int *pwrap, uint64_t *pcache_size_block,
-	int *pblock_order, progress_cb cb, int show_progress)
+int probe_device(struct device *dev, struct probe_results *results,
+	progress_cb cb, int show_progress)
 {
 	const uint64_t dev_size_byte = dev_get_size_byte(dev);
 	const int block_order = dev_get_block_order(dev);
@@ -916,23 +915,23 @@ int probe_device(struct device *dev, uint64_t *preal_size_byte,
 		right_pos = 0;
 	}
 
-	*preal_size_byte = right_pos << block_order;
-	*pwrap = wrap;
+	results->real_size_byte = right_pos << block_order;
+	results->wrap = wrap;
 	goto out;
 
 bad:
-	*preal_size_byte = 0;
-	*pwrap = ceiling_log2(dev_size_byte);
+	results->real_size_byte = 0;
+	results->wrap = ceiling_log2(dev_size_byte);
 
 out:
 	dbuf_free(&rwi.seqw_dbuf);
 	report_probed_size(0, cb, "=> Usable size:",
-		*preal_size_byte, block_order);
+		results->real_size_byte, block_order);
 	report_io_speed(0, cb, "=> Average sequential write speed:", &rwi.seqw_fw);
 	report_io_speed(0, cb, "=> Average random write speed:", &rwi.randw_fw);
 	report_io_speed(0, cb, "=> Average random read speed:", &rwi.randr_fw);
-	*pannounced_size_byte = dev_size_byte;
-	*pcache_size_block = rwi.cache_size_block;
-	*pblock_order = block_order;
+	results->announced_size_byte = dev_size_byte;
+	results->cache_size_block = rwi.cache_size_block;
+	results->block_order = block_order;
 	return false;
 }

--- a/libprobe.c
+++ b/libprobe.c
@@ -820,7 +820,8 @@ void report_probed_cache(unsigned int indent, progress_cb cb,
 }
 
 int probe_device(struct device *dev, struct probe_results *results,
-	progress_cb cb, int show_progress)
+	progress_cb cb, int show_progress,
+	long max_read_rate, long max_write_rate)
 {
 	const uint64_t dev_size_byte = dev_get_size_byte(dev);
 	const int block_order = dev_get_block_order(dev);
@@ -836,9 +837,9 @@ int probe_device(struct device *dev, struct probe_results *results,
 	/* We initialize total_size to 0 because inc_total_size() is called
 	 * to update it when new blocks become available.
 	 */
-	init_flow(&rwi.seqw_fw, block_size, 0, 0, fw_cb, 0, NULL);
-	init_flow(&rwi.randw_fw, block_size, 0, 0, fw_cb, 0, NULL);
-	init_flow(&rwi.randr_fw, block_size, 0, 0, fw_cb, 0, NULL);
+	init_flow(&rwi.seqw_fw, block_size, 0, max_write_rate, fw_cb, 0, NULL);
+	init_flow(&rwi.randw_fw, block_size, 0, max_write_rate, fw_cb, 0, NULL);
+	init_flow(&rwi.randr_fw, block_size, 0, max_read_rate, fw_cb, 0, NULL);
 
 	/* @left_pos must point to a good block.
 	 * We just point to the last block of the first 1MB of the card

--- a/libprobe.c
+++ b/libprobe.c
@@ -829,7 +829,7 @@ static void report_io_speed(unsigned int indent, progress_cb cb,
 
 	speed = (blocks * fw_get_block_size(fw) * 1000000000.0) / time_ns;
 	unit = adjust_unit(&speed);
-	usec_to_str(time_ns / 1000, time_str);
+	nsec_to_str(time_ns, time_str);
 	cb(indent, "%s %.2f %s/s (%" PRIu64 " blocks / %s)\n",
 		prefix, speed, unit, blocks, time_str);
 }

--- a/libprobe.c
+++ b/libprobe.c
@@ -813,6 +813,27 @@ void report_probed_cache(unsigned int indent, progress_cb cb,
 		prefix, f, unit, cache_size_block);
 }
 
+static void report_io_speed(unsigned int indent, progress_cb cb,
+	const char *prefix, const struct flow *fw)
+{
+	uint64_t blocks, time_ns;
+	double speed;
+	const char *unit;
+	char time_str[TIME_STR_SIZE];
+
+	fw_get_measurements(fw, &blocks, &time_ns);
+	if (time_ns == 0) {
+		cb(indent, "%s NO DATA\n", prefix);
+		return;
+	}
+
+	speed = (blocks * fw_get_block_size(fw) * 1000000000.0) / time_ns;
+	unit = adjust_unit(&speed);
+	usec_to_str(time_ns / 1000, time_str);
+	cb(indent, "%s %.2f %s/s (%" PRIu64 " blocks / %s)\n",
+		prefix, speed, unit, blocks, time_str);
+}
+
 int probe_device(struct device *dev, uint64_t *preal_size_byte,
 	uint64_t *pannounced_size_byte, int *pwrap, uint64_t *pcache_size_block,
 	int *pblock_order, progress_cb cb, int show_progress)
@@ -907,6 +928,9 @@ out:
 	dbuf_free(&rwi.seqw_dbuf);
 	report_probed_size(0, cb, "=> Usable size:",
 		*preal_size_byte, block_order);
+	report_io_speed(0, cb, "=> Average sequential write speed:", &rwi.seqw_fw);
+	report_io_speed(0, cb, "=> Average random write speed:", &rwi.randw_fw);
+	report_io_speed(0, cb, "=> Average random read speed:", &rwi.randr_fw);
 	*pannounced_size_byte = dev_size_byte;
 	*pcache_size_block = rwi.cache_size_block;
 	*pblock_order = block_order;

--- a/libprobe.c
+++ b/libprobe.c
@@ -813,26 +813,6 @@ void report_probed_cache(unsigned int indent, progress_cb cb,
 		prefix, f, unit, cache_size_block);
 }
 
-void report_probed_io_speed(unsigned int indent, progress_cb cb,
-	const char *prefix, uint64_t blocks, uint64_t time_ns,
-	int block_order)
-{
-	double speed;
-	const char *unit;
-	char time_str[TIME_STR_SIZE];
-
-	if (time_ns == 0) {
-		cb(indent, "%s NO DATA\n", prefix);
-		return;
-	}
-
-	speed = (blocks << block_order) * 1000000000.0 / time_ns;
-	unit = adjust_unit(&speed);
-	nsec_to_str(time_ns, time_str);
-	cb(indent, "%s %.2f %s/s (%" PRIu64 " blocks / %s)\n",
-		prefix, speed, unit, blocks, time_str);
-}
-
 int probe_device(struct device *dev, struct probe_results *results,
 	progress_cb cb, int show_progress)
 {
@@ -933,12 +913,15 @@ out:
 		&results->randw_time_ns);
 	fw_get_measurements(&rwi.randr_fw, &results->randr_blocks,
 		&results->randr_time_ns);
-	report_probed_io_speed(0, cb, "=> Sequential write:",
-		results->seqw_blocks, results->seqw_time_ns, block_order);
-	report_probed_io_speed(0, cb, "=> Random write:",
-		results->randw_blocks, results->randw_time_ns, block_order);
-	report_probed_io_speed(0, cb, "=> Random read:",
-		results->randr_blocks, results->randr_time_ns, block_order);
+	report_io_speed(0, cb, "=> Sequential write:",
+		results->seqw_blocks, "block", results->seqw_time_ns,
+		block_order);
+	report_io_speed(0, cb, "=> Random write:",
+		results->randw_blocks, "block", results->randw_time_ns,
+		block_order);
+	report_io_speed(0, cb, "=> Random read:",
+		results->randr_blocks, "block", results->randr_time_ns,
+		block_order);
 	results->announced_size_byte = dev_size_byte;
 	results->cache_size_block = rwi.cache_size_block;
 	results->block_order = block_order;

--- a/libprobe.c
+++ b/libprobe.c
@@ -439,7 +439,7 @@ static int find_a_bad_block(struct device *dev, uint32_t n_samples,
 	 */
 	fill_samples(samples, &n_samples, left_pos + 1, *pright_pos - 1, true,
 		&is_linear);
-	cb(indent, "## Sampling %" PRIu32 " blocks from blocks (%" PRIu64 ", %" PRIu64 ")\n",
+	cb(indent, "### Sampling %" PRIu32 " blocks from blocks (%" PRIu64 ", %" PRIu64 ")\n",
 		n_samples, left_pos, *pright_pos);
 
 	cb(indent + 1, "Writing random blocks\n");
@@ -498,7 +498,7 @@ static int sampling_probe(struct device *dev,
 	bool phase1 = true;
 
 	assert(SAMPLING_MAX >= SAMPLING_MIN);
-	cb(indent, "# Sampling\n");
+	cb(indent, "## Sampling\n");
 
 	while (*pright_pos > left_pos + n_samples + 1) {
 		if (find_a_bad_block(dev, n_samples, left_pos, pright_pos,
@@ -530,7 +530,7 @@ static void report_cache_size_test(unsigned int indent, progress_cb cb,
 {
 	double f_size = (last_pos - first_pos + 1) * dev_get_block_size(dev);
 	const char *unit = adjust_unit(&f_size);
-	cb(indent, "## Testing cache size: %.2f %s; Blocks [%" PRIu64 ", %" PRIu64 "]\n",
+	cb(indent, "### Testing cache size: %.2f %s; Blocks [%" PRIu64 ", %" PRIu64 "]\n",
 		f_size, unit, first_pos, last_pos);
 }
 
@@ -547,7 +547,7 @@ static int find_cache_size(struct device *dev, const uint64_t left_pos,
 	uint64_t final_write_target = MAX_CACHE_SIZE_BYTE >> block_order;
 	uint64_t first_pos = *pright_pos;
 
-	cb(indent, "# Find cache size\n");
+	cb(indent, "## Find cache size\n");
 
 	assert(write_target > 0);
 	assert(write_target < final_write_target);
@@ -640,7 +640,7 @@ static int find_wrap(struct device *dev,
 	uint32_t i;
 	enum block_state bs;
 
-	cb(indent, "# Find module\n");
+	cb(indent, "## Find module\n");
 
 	/*
 	 *	Basis

--- a/libprobe.c
+++ b/libprobe.c
@@ -813,21 +813,20 @@ void report_probed_cache(unsigned int indent, progress_cb cb,
 		prefix, f, unit, cache_size_block);
 }
 
-static void report_io_speed(unsigned int indent, progress_cb cb,
-	const char *prefix, const struct flow *fw)
+void report_probed_io_speed(unsigned int indent, progress_cb cb,
+	const char *prefix, uint64_t blocks, uint64_t time_ns,
+	int block_order)
 {
-	uint64_t blocks, time_ns;
 	double speed;
 	const char *unit;
 	char time_str[TIME_STR_SIZE];
 
-	fw_get_measurements(fw, &blocks, &time_ns);
 	if (time_ns == 0) {
 		cb(indent, "%s NO DATA\n", prefix);
 		return;
 	}
 
-	speed = (blocks * fw_get_block_size(fw) * 1000000000.0) / time_ns;
+	speed = (blocks << block_order) * 1000000000.0 / time_ns;
 	unit = adjust_unit(&speed);
 	nsec_to_str(time_ns, time_str);
 	cb(indent, "%s %.2f %s/s (%" PRIu64 " blocks / %s)\n",
@@ -927,9 +926,19 @@ out:
 	dbuf_free(&rwi.seqw_dbuf);
 	report_probed_size(0, cb, "=> Usable size:",
 		results->real_size_byte, block_order);
-	report_io_speed(0, cb, "=> Average sequential write speed:", &rwi.seqw_fw);
-	report_io_speed(0, cb, "=> Average random write speed:", &rwi.randw_fw);
-	report_io_speed(0, cb, "=> Average random read speed:", &rwi.randr_fw);
+	cb(0, "# I/O average speeds\n");
+	fw_get_measurements(&rwi.seqw_fw, &results->seqw_blocks,
+		&results->seqw_time_ns);
+	fw_get_measurements(&rwi.randw_fw, &results->randw_blocks,
+		&results->randw_time_ns);
+	fw_get_measurements(&rwi.randr_fw, &results->randr_blocks,
+		&results->randr_time_ns);
+	report_probed_io_speed(0, cb, "=> Sequential write:",
+		results->seqw_blocks, results->seqw_time_ns, block_order);
+	report_probed_io_speed(0, cb, "=> Random write:",
+		results->randw_blocks, results->randw_time_ns, block_order);
+	report_probed_io_speed(0, cb, "=> Random read:",
+		results->randr_blocks, results->randr_time_ns, block_order);
 	results->announced_size_byte = dev_size_byte;
 	results->cache_size_block = rwi.cache_size_block;
 	results->block_order = block_order;

--- a/libprobe.c
+++ b/libprobe.c
@@ -20,8 +20,8 @@ static int _write_blocks(struct device *dev, const char *buf,
 	if (dev_write_blocks(dev, buf, first_pos, last_pos) &&
 			dev_write_blocks(dev, buf, first_pos, last_pos)) {
 		clear_progress(fw);
-		cb(indent, "I/O ERROR: Write error at blocks [%" PRIu64 ", %" PRIu64 "]!\n",
-			first_pos, last_pos);
+		cb(indent, "I/O ERROR: Write error at block%s [%" PRIu64 ", %\" PRIu64 \"]!\n",
+			first_pos != last_pos ? "s" : "", first_pos, last_pos);
 		return true;
 	}
 	return false;
@@ -395,8 +395,9 @@ static int probabilistic_test(struct device *dev,
 
 	fill_samples(samples, &n_samples, first_pos, last_pos, false,
 		&is_linear);
-	cb(indent, "Sampling %" PRIu32 " blocks from blocks [%" PRIu64 ", %" PRIu64 "]\n",
-		n_samples, first_pos, last_pos);
+	cb(indent, "Sampling %" PRIu32 " block%s from block%s [%" PRIu64 ", %" PRIu64 "]\n",
+		n_samples, n_samples != 1 ? "s" : "",
+		first_pos != last_pos ? "s" : "", first_pos, last_pos);
 	if (find_first_bad_block(dev, samples, n_samples, &any_bad, &bad_pos,
 			rwi, cb, indent))
 		return true;
@@ -439,8 +440,9 @@ static int find_a_bad_block(struct device *dev, uint32_t n_samples,
 	 */
 	fill_samples(samples, &n_samples, left_pos + 1, *pright_pos - 1, true,
 		&is_linear);
-	cb(indent, "### Sampling %" PRIu32 " blocks from blocks (%" PRIu64 ", %" PRIu64 ")\n",
-		n_samples, left_pos, *pright_pos);
+	cb(indent, "### Sampling %" PRIu32 " block%s from block%s (%" PRIu64 ", %" PRIu64 ")\n",
+		n_samples, n_samples != 1 ? "s" : "",
+		*pright_pos != left_pos + 2 ? "s" : "", left_pos, *pright_pos);
 
 	cb(indent + 1, "Writing random blocks\n");
 
@@ -530,8 +532,9 @@ static void report_cache_size_test(unsigned int indent, progress_cb cb,
 {
 	double f_size = (last_pos - first_pos + 1) * dev_get_block_size(dev);
 	const char *unit = adjust_unit(&f_size);
-	cb(indent, "### Testing cache size: %.2f %s; Blocks [%" PRIu64 ", %" PRIu64 "]\n",
-		f_size, unit, first_pos, last_pos);
+	cb(indent, "### Testing cache size: %.2f %s; Block%s [%" PRIu64 ", %" PRIu64 "]\n",
+		f_size, unit, first_pos != last_pos ? "s" : "",
+		first_pos, last_pos);
 }
 
 /* This constant needs to be a power of 2 and larger than 2^block_order. */
@@ -577,8 +580,8 @@ static int find_cache_size(struct device *dev, const uint64_t left_pos,
 		/* Write @write_target blocks before
 		 * the previously written blocks.
 		 */
-		cb(indent + 2, "Writing blocks [%" PRIu64 ", %" PRIu64 "]\n",
-			first_pos, last_pos);
+		cb(indent + 2, "Writing block%s [%" PRIu64 ", %" PRIu64 "]\n",
+			first_pos != last_pos ? "s" : "", first_pos, last_pos);
 		if (write_blocks(dev, first_pos, last_pos, rwi, cb, indent + 2))
 			goto bad;
 
@@ -667,8 +670,8 @@ static int find_wrap(struct device *dev,
 	 *	Inductive step
 	 */
 
-	cb(indent + 1, "Probing module (reading %" PRIu32 " blocks)\n",
-		n_samples);
+	cb(indent + 1, "Probing module (reading %" PRIu32 " block%s)\n",
+		n_samples, n_samples != 1 ? "s" : "");
 
 	block_order = dev_get_block_order(dev);
 	expected_offset = good_block << block_order;
@@ -792,8 +795,9 @@ void report_probed_size(unsigned int indent, progress_cb cb,
 {
 	double f = bytes;
 	const char *unit = adjust_unit(&f);
-	cb(indent, "%s %.2f %s (%" PRIu64 " blocks)\n",
-		prefix, f, unit, bytes >> block_order);
+	uint64_t blocks = bytes >> block_order;
+	cb(indent, "%s %.2f %s (%" PRIu64 " block%s)\n",
+		prefix, f, unit, blocks, blocks != 1 ? "s" : "");
 }
 
 void report_probed_order(unsigned int indent, progress_cb cb,
@@ -801,7 +805,8 @@ void report_probed_order(unsigned int indent, progress_cb cb,
 {
 	double f = (1ULL << order);
 	const char *unit = adjust_unit(&f);
-	cb(indent, "%s %.2f %s (2^%i Bytes)\n", prefix, f, unit, order);
+	cb(indent, "%s %.2f %s (2^%i Byte%s)\n", prefix, f, unit, order,
+		order != 0 ? "s" : "");
 }
 
 void report_probed_cache(unsigned int indent, progress_cb cb,
@@ -809,8 +814,9 @@ void report_probed_cache(unsigned int indent, progress_cb cb,
 {
 	double f = (cache_size_block << block_order);
 	const char *unit = adjust_unit(&f);
-	cb(indent, "%s %.2f %s (%" PRIu64 " blocks)\n",
-		prefix, f, unit, cache_size_block);
+	cb(indent, "%s %.2f %s (%" PRIu64 " block%s)\n",
+		prefix, f, unit, cache_size_block,
+		cache_size_block != 1 ? "s" : "");
 }
 
 int probe_device(struct device *dev, struct probe_results *results,

--- a/libprobe.h
+++ b/libprobe.h
@@ -37,6 +37,7 @@ struct probe_results {
 };
 
 int probe_device(struct device *dev, struct probe_results *results,
-	progress_cb cb, int show_progress);
+	progress_cb cb, int show_progress,
+	long max_read_rate, long max_write_rate);
 
 #endif	/* HEADER_LIBPROBE_H */

--- a/libprobe.h
+++ b/libprobe.h
@@ -24,12 +24,20 @@ void report_probed_order(unsigned int indent, progress_cb cb,
 void report_probed_cache(unsigned int indent, progress_cb cb,
 	const char *prefix, uint64_t cache_size_block, int block_order);
 
+void report_probed_io_speed(unsigned int indent, progress_cb cb,
+	const char *prefix, uint64_t blocks, uint64_t time_ns,
+	int block_order);
+
 struct probe_results {
 	uint64_t real_size_byte;
 	uint64_t announced_size_byte;
 	int wrap;
 	uint64_t cache_size_block;
 	int block_order;
+
+	uint64_t seqw_blocks, seqw_time_ns;
+	uint64_t randw_blocks, randw_time_ns;
+	uint64_t randr_blocks, randr_time_ns;
 };
 
 int probe_device(struct device *dev, struct probe_results *results,

--- a/libprobe.h
+++ b/libprobe.h
@@ -24,9 +24,15 @@ void report_probed_order(unsigned int indent, progress_cb cb,
 void report_probed_cache(unsigned int indent, progress_cb cb,
 	const char *prefix, uint64_t cache_size_block, int block_order);
 
-int probe_device(struct device *dev, uint64_t *preal_size_byte,
-	uint64_t *pannounced_size_byte, int *pwrap,
-	uint64_t *pcache_size_block, int *pblock_order,
+struct probe_results {
+	uint64_t real_size_byte;
+	uint64_t announced_size_byte;
+	int wrap;
+	uint64_t cache_size_block;
+	int block_order;
+};
+
+int probe_device(struct device *dev, struct probe_results *results,
 	progress_cb cb, int show_progress);
 
 #endif	/* HEADER_LIBPROBE_H */

--- a/libprobe.h
+++ b/libprobe.h
@@ -24,10 +24,6 @@ void report_probed_order(unsigned int indent, progress_cb cb,
 void report_probed_cache(unsigned int indent, progress_cb cb,
 	const char *prefix, uint64_t cache_size_block, int block_order);
 
-void report_probed_io_speed(unsigned int indent, progress_cb cb,
-	const char *prefix, uint64_t blocks, uint64_t time_ns,
-	int block_order);
-
 struct probe_results {
 	uint64_t real_size_byte;
 	uint64_t announced_size_byte;

--- a/libutils.c
+++ b/libutils.c
@@ -59,76 +59,101 @@ const char *adjust_unit(double *ptr_bytes)
 	return units[i];
 }
 
-#define USEC_IN_A_MSEC	1000ULL
-#define USEC_IN_A_SEC	(1000*USEC_IN_A_MSEC)
-#define USEC_IN_A_MIN	(60*USEC_IN_A_SEC)
-#define USEC_IN_AN_HOUR	(60*USEC_IN_A_MIN)
-#define USEC_IN_A_DAY	(24*USEC_IN_AN_HOUR)
-
-int usec_to_str(uint64_t usec, char *str)
+int nsec_to_str(uint64_t nsec, char *str)
 {
-	int has_d, has_h, has_m, has_s;
+	const uint64_t nsec_in_a_usec	= 1000;
+	const uint64_t nsec_in_a_msec	= 1000	* nsec_in_a_usec;
+	const uint64_t nsec_in_a_sec	= 1000	* nsec_in_a_msec;
+	const uint64_t nsec_in_a_min	= 60	* nsec_in_a_sec;
+	const uint64_t nsec_in_an_hour	= 60	* nsec_in_a_min;
+	const uint64_t nsec_in_a_day	= 24	* nsec_in_an_hour;
+	const uint64_t nsec_in_a_week	= 7	* nsec_in_a_day;
+
+	bool has_w, has_d, has_h, has_m, has_s, has_prv = false;
 	lldiv_t div;
 	int c, tot = 0;
 
-	has_d = usec >= USEC_IN_A_DAY;
+	has_w = nsec >= nsec_in_a_week;
+	if (has_w) {
+		div = lldiv(nsec, nsec_in_a_week);
+		nsec = div.rem;
+		c = sprintf(str + tot, "%i week%s",
+			(int)div.quot, div.quot != 1 ? "s" : "");
+		assert(c > 0);
+		tot += c;
+		has_prv = true;
+	}
+
+	has_d = nsec >= nsec_in_a_day;
 	if (has_d) {
-		div = lldiv(usec, USEC_IN_A_DAY);
-		usec = div.rem;
-		c = sprintf(str + tot, "%i days", (int)div.quot);
+		div = lldiv(nsec, nsec_in_a_day);
+		nsec = div.rem;
+		c = sprintf(str + tot, "%s%i day%s",
+			has_prv ? " " : "", (int)div.quot,
+			div.quot != 1 ? "s" : "");
 		assert(c > 0);
 		tot += c;
+		has_prv = true;
 	}
 
-	has_h = usec >= USEC_IN_AN_HOUR;
+	has_h = nsec >= nsec_in_an_hour;
 	if (has_h) {
-		div = lldiv(usec, USEC_IN_AN_HOUR);
-		usec = div.rem;
+		div = lldiv(nsec, nsec_in_an_hour);
+		nsec = div.rem;
 		c = sprintf(str + tot, "%s%i:",
-			has_d ? " " : "", (int)div.quot);
+			has_prv ? " " : "", (int)div.quot);
 		assert(c > 0);
 		tot += c;
+		has_prv = true;
 	}
 
-	has_m = has_h || usec >= USEC_IN_A_MIN;
+	has_m = has_h || nsec >= nsec_in_a_min;
 	if (has_m) {
-		div = lldiv(usec, USEC_IN_A_MIN);
-		usec = div.rem;
+		div = lldiv(nsec, nsec_in_a_min);
+		nsec = div.rem;
 		if (has_h)
 			c = sprintf(str + tot, "%02i", (int)div.quot);
 		else
-			c = sprintf(str + tot, "%i'", (int)div.quot);
+			c = sprintf(str + tot, "%s%i'",
+				has_prv ? " " : "", (int)div.quot);
 		assert(c > 0);
 		tot += c;
+		has_prv = true;
 	}
 
-	has_s = usec >= USEC_IN_A_SEC;
+	has_s = nsec >= nsec_in_a_sec;
 	if (has_s) {
-		div = lldiv(usec, USEC_IN_A_SEC);
-		usec = div.rem;
+		div = lldiv(nsec, nsec_in_a_sec);
+		nsec = div.rem;
 		if (has_h)
 			c = sprintf(str + tot, ":%02i", (int)div.quot);
 		else if (has_m)
 			c = sprintf(str + tot, "%02i\"", (int)div.quot);
-		else if (has_d)
-			c = sprintf(str + tot, "%is", (int)div.quot);
+		else if (has_prv)
+			c = sprintf(str + tot, " %is", (int)div.quot);
 		else
 			c = sprintf(str + tot, "%i.%02is", (int)div.quot,
-				(int)(usec / (10 * USEC_IN_A_MSEC)));
+				(int)(nsec / (10 * nsec_in_a_msec)));
 		assert(c > 0);
 		tot += c;
+		has_prv = true;
 	}
 
-	if (has_d || has_h || has_m || has_s)
+	if (has_prv)
 		return tot;
 
-	if (usec >= USEC_IN_A_MSEC) {
-		div = lldiv(usec, USEC_IN_A_MSEC);
-		usec = div.rem;
+	if (nsec >= nsec_in_a_msec) {
+		div = lldiv(nsec, nsec_in_a_msec);
+		nsec = div.rem;
 		c = sprintf(str + tot, "%i.%ims", (int)div.quot,
-			(int)(usec / 100));
+			(int)(nsec / (100 * nsec_in_a_usec)));
+	} else if (nsec >= nsec_in_a_usec) {
+		div = lldiv(nsec, nsec_in_a_usec);
+		nsec = div.rem;
+		c = sprintf(str + tot, "%i.%ius", (int)div.quot,
+			(int)(nsec / 100));
 	} else {
-		c = sprintf(str + tot, "%ius", (int)usec);
+		c = sprintf(str + tot, "%ins", (int)nsec);
 	}
 	assert(c > 0);
 	tot += c;

--- a/libutils.c
+++ b/libutils.c
@@ -349,6 +349,27 @@ void print_stats(const struct block_stats *stats, int block_size,
 	print_stat("\t     Overwritten:", stats->overwritten, block_size, unit_name);
 }
 
+void report_io_speed(unsigned int indent, progress_cb cb, const char *prefix,
+	uint64_t blocks, const char *block_unit, uint64_t time_ns,
+	int block_order)
+{
+	double speed;
+	const char *unit;
+	char time_str[TIME_STR_SIZE];
+
+	if (time_ns == 0) {
+		cb(indent, "%s NO DATA\n", prefix);
+		return;
+	}
+
+	speed = (blocks << block_order) * 1000000000.0 / time_ns;
+	unit = adjust_unit(&speed);
+	nsec_to_str(time_ns, time_str);
+	cb(indent, "%s %.2f %s/s (%" PRIu64 " %s%s / %s)\n",
+		prefix, speed, unit, blocks, block_unit,
+		blocks != 1 ? "s" : "", time_str);
+}
+
 static void print_indent(unsigned int indent, const char *indent_str)
 {
 	unsigned int i;

--- a/libutils.c
+++ b/libutils.c
@@ -47,16 +47,18 @@ uint64_t clp2(uint64_t x)
 
 const char *adjust_unit(double *ptr_bytes)
 {
-	const char *units[] = { "Byte", "KB", "MB", "GB", "TB", "PB", "EB" };
-	int i = 0;
+	const char *units[] = {"Bytes", "KB", "MB", "GB", "TB", "PB", "EB"};
+	unsigned int i = 0;
 	double final = *ptr_bytes;
 
-	while (i < 7 && final >= 1024) {
+	while (i < DIM(units) && final >= 1024) {
 		final /= 1024;
 		i++;
 	}
 	*ptr_bytes = final;
-	return units[i];
+	if (i > 0 || final != 1.0)
+		return units[i];
+	return "Byte";
 }
 
 int nsec_to_str(uint64_t nsec, char *str)
@@ -331,10 +333,10 @@ enum block_state validate_block_update_stats(const void *buf, int block_order,
 static void print_stat(const char *prefix, uint64_t count,
 	int block_size, const char *unit_name)
 {
-	double f = (double) count * block_size;
+	double f = (double)count * block_size;
 	const char *unit = adjust_unit(&f);
-	printf("%s %.2f %s (%" PRIu64 " %s)\n",
-		prefix, f, unit, count, unit_name);
+	printf("%s %.2f %s (%" PRIu64 " %s%s)\n",
+		prefix, f, unit, count, unit_name, count != 1 ? "s" : "");
 }
 
 void print_stats(const struct block_stats *stats, int block_size,

--- a/libutils.h
+++ b/libutils.h
@@ -110,4 +110,8 @@ static inline uint64_t diff_timespec_ns(const struct timespec *t1,
 void print_stats(const struct block_stats *stats, int block_size,
 	const char *unit_name);
 
+void report_io_speed(unsigned int indent, progress_cb cb, const char *prefix,
+	uint64_t blocks, const char *block_unit, uint64_t time_ns,
+	int block_order);
+
 #endif	/* HEADER_LIBUTILS_H */

--- a/libutils.h
+++ b/libutils.h
@@ -32,7 +32,7 @@ const char *adjust_unit(double *ptr_bytes);
 
 #define TIME_STR_SIZE	128
 
-int usec_to_str(uint64_t usec, char *str);
+int nsec_to_str(uint64_t nsec, char *str);
 
 /*
  * The functions align_head() and align_mem() are used to align pointers.


### PR DESCRIPTION
This pull request improves `f3probe` to report I/O speeds in the final probe report when the flag `--destructive` is used, and in the `--verbose` output. `f3probe` requires the flag `--destructive` to report I/O speeds in the final probe report because the safe device disrupts the measurements. I/O speeds are always present in the `--verbose` output because it is meant to support diagnoses and to give users the option to follow the probe.

In addition, this pull request adds parameters `--max-read-rate` and `--max-write-rate` to `f3probe`. These parameters are meant to enable users to probe drives that overheat under maximum read and write rates. Fortunately, this is a rare use case nowadays.

Finally, this pull request standardizes the report of I/O speeds in line with `f3probe` for `f3read`, `f3write`, and `f3brew`. Meaning that these reports emphasize **sequential** measurements (i.e., no random reads or writes), include the number of blocks and the measured time, and use "read" and "write" instead of "writing" and "reading".