### PR TITLE
Review libflow's interface

### DIFF
--- a/src/f3brew.c
+++ b/src/f3brew.c
@@ -301,13 +301,10 @@ static void write_blocks(struct device *dev, struct flow *fw,
 				" to 0x%" PRIx64, first_pos, next_pos);
 		}
 
-		/* Since parameter func_flush_chunk of init_flow() is NULL,
-		 * the parameter fd of measure() is ignored.
-		 */
-		measure(0, fw, blocks_to_write << block_order);
+		measure(fw, blocks_to_write << block_order);
 		first_pos = next_pos + 1;
 	}
-	end_measurement(0, fw);
+	end_measurement(fw);
 	dbuf_free(&dbuf);
 }
 
@@ -326,7 +323,7 @@ static void test_write_blocks(struct device *dev,
 	fflush(stdout);
 
 	init_flow(&fw, block_size, total_size, max_write_rate,
-		show_progress ? printf_flush_cb : dummy_cb, 0, NULL);
+		show_progress ? printf_flush_cb : dummy_cb, 0);
 
 	write_blocks(dev, &fw, first_block, last_block);
 
@@ -468,13 +465,10 @@ static void read_blocks(struct device *dev, struct flow *fw,
 			probe_blk += block_size;
 		}
 
-		/* Since parameter func_flush_chunk of init_flow() is NULL,
-		 * the parameter fd of measure() is ignored.
-		 */
-		measure(0, fw, blocks_to_read << block_order);
+		measure(fw, blocks_to_read << block_order);
 		first_pos = next_pos + 1;
 	}
-	end_measurement(0, fw);
+	end_measurement(fw);
 	dbuf_free(&dbuf);
 
 	if (range.state != bs_unknown)
@@ -498,7 +492,7 @@ static void test_read_blocks(struct device *dev,
 		first_block != last_block ? "s" : "", first_block, last_block);
 
 	init_flow(&fw, block_size, total_size, max_read_rate,
-		show_progress ? printf_flush_cb : dummy_cb, 0, NULL);
+		show_progress ? printf_flush_cb : dummy_cb, 0);
 
 	read_blocks(dev, &fw, first_block, last_block, &stats);
 

--- a/src/f3brew.c
+++ b/src/f3brew.c
@@ -84,7 +84,7 @@ struct args {
 	uint64_t	real_size_byte;
 	uint64_t	fake_size_byte;
 	int		wrap;
-	int		block_order;
+	unsigned int	block_order;
 	int		cache_order;
 	int		strict_cache;
 
@@ -258,8 +258,8 @@ static struct argp argp = {options, parse_opt, adoc, doc, NULL, NULL, NULL};
 static void write_blocks(struct device *dev, struct flow *fw,
 	uint64_t first_block, uint64_t last_block)
 {
-	const int block_size = dev_get_block_size(dev);
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	uint64_t offset = first_block << block_order;
 	uint64_t first_pos = first_block;
 	struct dynamic_buffer dbuf;
@@ -305,7 +305,7 @@ static void test_write_blocks(struct device *dev,
 	uint64_t first_block, uint64_t last_block,
 	long max_write_rate, int show_progress)
 {
-	const int block_size = dev_get_block_size(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
 	const uint64_t total_blocks = last_block - first_block + 1;
 	struct flow fw;
 
@@ -325,7 +325,7 @@ static void test_write_blocks(struct device *dev,
 
 struct block_range {
 	enum block_state	state;
-	int			block_order;
+	unsigned int		block_order;
 	uint64_t		start_sector_offset;
 	uint64_t		end_sector_offset;
 
@@ -333,12 +333,12 @@ struct block_range {
 	uint64_t		found_sector_offset;
 };
 
-static int is_block(uint64_t offset, int block_order)
+static int is_block(uint64_t offset, unsigned int block_order)
 {
 	return !(((1ULL << block_order) - 1) & offset);
 }
 
-static void print_offset(uint64_t offset, int block_order)
+static void print_offset(uint64_t offset, unsigned int block_order)
 {
 	assert(is_block(offset, block_order));
 	printf("block 0x%" PRIx64, offset >> block_order);
@@ -370,8 +370,8 @@ static void print_block_range(const struct block_range *range)
 }
 
 static void validate_block(struct flow *fw, uint64_t expected_sector_offset,
-	const char *probe_blk, int block_order, struct block_range *range,
-	struct block_stats *stats)
+	const char *probe_blk, unsigned int block_order,
+	struct block_range *range, struct block_stats *stats)
 {
 	uint64_t found_sector_offset;
 	enum block_state state = validate_block_update_stats(probe_blk, block_order,
@@ -406,8 +406,8 @@ static void validate_block(struct flow *fw, uint64_t expected_sector_offset,
 static void read_blocks(struct device *dev, struct flow *fw,
 	uint64_t first_block, uint64_t last_block, struct block_stats *stats)
 {
-	const int block_size = dev_get_block_size(dev);
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	uint64_t expected_sector_offset = first_block << block_order;
 	uint64_t first_pos = first_block;
 	struct block_range range = {
@@ -466,7 +466,7 @@ static void test_read_blocks(struct device *dev,
 	uint64_t first_block, uint64_t last_block,
 	long max_read_rate, int show_progress)
 {
-	const int block_size = dev_get_block_size(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
 	const uint64_t total_blocks = last_block - first_block + 1;
 	struct flow fw;
 	struct block_stats stats = { 0, 0, 0, 0 };
@@ -507,7 +507,7 @@ int main(int argc, char **argv)
 		.show_progress	= isatty(STDOUT_FILENO),
 	};
 	struct device *dev;
-	int block_order;
+	unsigned int block_order;
 	uint64_t very_last_block;
 
 	/* Read parameters. */

--- a/src/f3brew.c
+++ b/src/f3brew.c
@@ -306,15 +306,14 @@ static void test_write_blocks(struct device *dev,
 	long max_write_rate, int show_progress)
 {
 	const int block_size = dev_get_block_size(dev);
-	const int block_order = dev_get_block_order(dev);
-	const uint64_t total_size = (last_block - first_block + 1) << block_order;
+	const uint64_t total_blocks = last_block - first_block + 1;
 	struct flow fw;
 
 	printf("Writing block%s from 0x%" PRIx64 " to 0x%" PRIx64 "... ",
 		first_block != last_block ? "s" : "", first_block, last_block);
 	fflush(stdout);
 
-	init_flow(&fw, block_size, total_size, max_write_rate,
+	init_flow(&fw, block_size, total_blocks, max_write_rate,
 		show_progress ? printf_flush_cb : dummy_cb, 0);
 
 	write_blocks(dev, &fw, first_block, last_block);
@@ -468,15 +467,14 @@ static void test_read_blocks(struct device *dev,
 	long max_read_rate, int show_progress)
 {
 	const int block_size = dev_get_block_size(dev);
-	const int block_order = dev_get_block_order(dev);
-	const uint64_t total_size = (last_block - first_block + 1) << block_order;
+	const uint64_t total_blocks = last_block - first_block + 1;
 	struct flow fw;
 	struct block_stats stats = { 0, 0, 0, 0 };
 
 	printf("Reading block%s from 0x%" PRIx64 " to 0x%" PRIx64 ":\n",
 		first_block != last_block ? "s" : "", first_block, last_block);
 
-	init_flow(&fw, block_size, total_size, max_read_rate,
+	init_flow(&fw, block_size, total_blocks, max_read_rate,
 		show_progress ? printf_flush_cb : dummy_cb, 0);
 
 	read_blocks(dev, &fw, first_block, last_block, &stats);

--- a/src/f3brew.c
+++ b/src/f3brew.c
@@ -268,16 +268,16 @@ static void write_blocks(struct device *dev, struct flow *fw,
 
 	start_measurement(fw);
 	while (first_pos <= last_block) {
-		const uint64_t chunk_bytes = get_rem_chunk_size(fw);
 		const uint64_t max_blocks_to_write = last_block - first_pos + 1;
-		size_t buf_len = chunk_bytes;
-		uint64_t blocks_to_write;
+		uint64_t blocks_to_write =
+			MIN(get_rem_chunk_blocks(fw), max_blocks_to_write);
+		size_t buf_len = blocks_to_write << block_order;
 		char *buffer, *stamp_blk;
 		uint64_t pos, next_pos;
 
 		buffer = dbuf_get_buf(&dbuf, block_order, &buf_len);
-		blocks_to_write =
-			MIN(buf_len >> block_order, max_blocks_to_write);
+		blocks_to_write = buf_len >> block_order;
+		assert(blocks_to_write > 0);
 		next_pos = first_pos + blocks_to_write;
 
 		stamp_blk = buffer;
@@ -293,7 +293,7 @@ static void write_blocks(struct device *dev, struct flow *fw,
 				" to 0x%" PRIx64, first_pos, next_pos - 1);
 		}
 
-		measure(fw, blocks_to_write << block_order);
+		measure(fw, blocks_to_write);
 		first_pos = next_pos;
 	}
 	end_measurement(fw);
@@ -423,16 +423,16 @@ static void read_blocks(struct device *dev, struct flow *fw,
 
 	start_measurement(fw);
 	while (first_pos <= last_block) {
-		const uint64_t chunk_bytes = get_rem_chunk_size(fw);
 		const uint64_t max_blocks_to_read = last_block - first_pos + 1;
-		size_t buf_len = chunk_bytes;
-		uint64_t blocks_to_read;
+		uint64_t blocks_to_read =
+			MIN(get_rem_chunk_blocks(fw), max_blocks_to_read);
+		size_t buf_len = blocks_to_read << block_order;
 		char *buffer, *probe_blk;
 		uint64_t pos, next_pos;
 
 		buffer = dbuf_get_buf(&dbuf, block_order, &buf_len);
-		blocks_to_read =
-			MIN(buf_len >> block_order, max_blocks_to_read);
+		blocks_to_read = buf_len >> block_order;
+		assert(blocks_to_read > 0);
 		next_pos = first_pos + blocks_to_read;
 
 		if (dev_read_blocks(dev, buffer, first_pos, next_pos - 1)) {
@@ -449,7 +449,7 @@ static void read_blocks(struct device *dev, struct flow *fw,
 			probe_blk += block_size;
 		}
 
-		measure(fw, blocks_to_read << block_order);
+		measure(fw, blocks_to_read);
 		first_pos = next_pos;
 	}
 	end_measurement(fw);

--- a/src/f3brew.c
+++ b/src/f3brew.c
@@ -269,40 +269,32 @@ static void write_blocks(struct device *dev, struct flow *fw,
 	start_measurement(fw);
 	while (first_pos <= last_block) {
 		const uint64_t chunk_bytes = get_rem_chunk_size(fw);
-		const uint64_t needed_size = align_head(block_order) + chunk_bytes;
 		const uint64_t max_blocks_to_write = last_block - first_pos + 1;
+		size_t buf_len = chunk_bytes;
 		uint64_t blocks_to_write;
-		int shift;
 		char *buffer, *stamp_blk;
-		size_t buf_len;
 		uint64_t pos, next_pos;
 
-		buffer = align_mem2(dbuf_get_buf(&dbuf, needed_size), block_order, &shift);
-		buf_len = dbuf_get_len(&dbuf);
-
-		blocks_to_write = buf_len >= needed_size
-			? chunk_bytes >> block_order
-			: (buf_len - shift) >> block_order;
-		if (blocks_to_write > max_blocks_to_write)
-			blocks_to_write = max_blocks_to_write;
-
-		next_pos = first_pos + blocks_to_write - 1;
+		buffer = dbuf_get_buf(&dbuf, block_order, &buf_len);
+		blocks_to_write =
+			MIN(buf_len >> block_order, max_blocks_to_write);
+		next_pos = first_pos + blocks_to_write;
 
 		stamp_blk = buffer;
-		for (pos = first_pos; pos <= next_pos; pos++) {
+		for (pos = first_pos; pos < next_pos; pos++) {
 			fill_buffer_with_block(stamp_blk, block_order, offset, 0);
 			stamp_blk += block_size;
 			offset += block_size;
 		}
 
-		if (dev_write_blocks(dev, buffer, first_pos, next_pos)) {
+		if (dev_write_blocks(dev, buffer, first_pos, next_pos - 1)) {
 			clear_progress(fw);
 			warn("Failed to write blocks from 0x%" PRIx64
-				" to 0x%" PRIx64, first_pos, next_pos);
+				" to 0x%" PRIx64, first_pos, next_pos - 1);
 		}
 
 		measure(fw, blocks_to_write << block_order);
-		first_pos = next_pos + 1;
+		first_pos = next_pos;
 	}
 	end_measurement(fw);
 	dbuf_free(&dbuf);
@@ -433,32 +425,25 @@ static void read_blocks(struct device *dev, struct flow *fw,
 	start_measurement(fw);
 	while (first_pos <= last_block) {
 		const uint64_t chunk_bytes = get_rem_chunk_size(fw);
-		const uint64_t needed_size = align_head(block_order) + chunk_bytes;
 		const uint64_t max_blocks_to_read = last_block - first_pos + 1;
+		size_t buf_len = chunk_bytes;
 		uint64_t blocks_to_read;
-		int shift;
 		char *buffer, *probe_blk;
-		size_t buf_len;
 		uint64_t pos, next_pos;
 
-		buffer = align_mem2(dbuf_get_buf(&dbuf, needed_size), block_order, &shift);
-		buf_len = dbuf_get_len(&dbuf);
+		buffer = dbuf_get_buf(&dbuf, block_order, &buf_len);
+		blocks_to_read =
+			MIN(buf_len >> block_order, max_blocks_to_read);
+		next_pos = first_pos + blocks_to_read;
 
-		blocks_to_read = buf_len >= needed_size
-			? chunk_bytes >> block_order
-			: (buf_len - shift) >> block_order;
-		if (blocks_to_read > max_blocks_to_read)
-			blocks_to_read = max_blocks_to_read;
-
-		next_pos = first_pos + blocks_to_read - 1;
-		if (dev_read_blocks(dev, buffer, first_pos, next_pos)) {
+		if (dev_read_blocks(dev, buffer, first_pos, next_pos - 1)) {
 			clear_progress(fw);
 			warn("Failed to read blocks from 0x%" PRIx64
-				" to 0x%" PRIx64, first_pos, next_pos);
+				" to 0x%" PRIx64, first_pos, next_pos - 1);
 		}
 
 		probe_blk = buffer;
-		for (pos = first_pos; pos <= next_pos; pos++) {
+		for (pos = first_pos; pos < next_pos; pos++) {
 			validate_block(fw, expected_sector_offset, probe_blk,
 				block_order, &range, stats);
 			expected_sector_offset += block_size;
@@ -466,7 +451,7 @@ static void read_blocks(struct device *dev, struct flow *fw,
 		}
 
 		measure(fw, blocks_to_read << block_order);
-		first_pos = next_pos + 1;
+		first_pos = next_pos;
 	}
 	end_measurement(fw);
 	dbuf_free(&dbuf);

--- a/src/f3brew.c
+++ b/src/f3brew.c
@@ -305,7 +305,7 @@ static void test_write_blocks(struct device *dev,
 	uint64_t first_block, uint64_t last_block,
 	long max_write_rate, int show_progress)
 {
-	const unsigned int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	const uint64_t total_blocks = last_block - first_block + 1;
 	struct flow fw;
 
@@ -313,7 +313,7 @@ static void test_write_blocks(struct device *dev,
 		first_block != last_block ? "s" : "", first_block, last_block);
 	fflush(stdout);
 
-	init_flow(&fw, block_size, total_blocks, max_write_rate,
+	init_flow(&fw, block_order, total_blocks, max_write_rate,
 		show_progress ? printf_flush_cb : dummy_cb, 0);
 
 	write_blocks(dev, &fw, first_block, last_block);
@@ -466,7 +466,7 @@ static void test_read_blocks(struct device *dev,
 	uint64_t first_block, uint64_t last_block,
 	long max_read_rate, int show_progress)
 {
-	const unsigned int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	const uint64_t total_blocks = last_block - first_block + 1;
 	struct flow fw;
 	struct block_stats stats = { 0, 0, 0, 0 };
@@ -474,12 +474,12 @@ static void test_read_blocks(struct device *dev,
 	printf("Reading block%s from 0x%" PRIx64 " to 0x%" PRIx64 ":\n",
 		first_block != last_block ? "s" : "", first_block, last_block);
 
-	init_flow(&fw, block_size, total_blocks, max_read_rate,
+	init_flow(&fw, block_order, total_blocks, max_read_rate,
 		show_progress ? printf_flush_cb : dummy_cb, 0);
 
 	read_blocks(dev, &fw, first_block, last_block, &stats);
 
-	print_stats(&stats, block_size, "block");
+	print_stats(&stats, block_order, "block");
 	print_avg_seq_speed(&fw, "read", false);
 	printf("\n");
 }

--- a/src/f3probe.c
+++ b/src/f3probe.c
@@ -86,7 +86,7 @@ struct args {
 	uint64_t	real_size_byte;
 	uint64_t	fake_size_byte;
 	int		wrap;
-	int		block_order;
+	unsigned int	block_order;
 	int		cache_order;
 	int		strict_cache;
 };
@@ -232,7 +232,7 @@ struct unit_test_item {
 	uint64_t	real_size_byte;
 	uint64_t	fake_size_byte;
 	int		wrap;
-	int		block_order;
+	unsigned int	block_order;
 	int		cache_order;
 	int		strict_cache;
 };
@@ -357,25 +357,25 @@ static int unit_test(const char *filename)
 }
 
 static inline void report_size(const char *prefix, uint64_t bytes,
-	int block_order)
+	unsigned int block_order)
 {
 	report_probed_size(0, printf_cb, prefix, bytes, block_order);
 }
 
-static inline void report_order(const char *prefix, int order)
+static inline void report_order(const char *prefix, unsigned int order)
 {
 	report_probed_order(0, printf_cb, prefix, order);
 }
 
 static inline void report_cache(const char *prefix, uint64_t cache_size_block,
-	int block_order)
+	unsigned int block_order)
 {
 	report_probed_cache(0, printf_cb, prefix, cache_size_block,
 		block_order);
 }
 
 static inline void report_speed(const char *prefix, uint64_t blocks,
-	uint64_t time_ns, int block_order)
+	uint64_t time_ns, unsigned int block_order)
 {
 	report_io_speed(0, printf_cb, prefix, blocks, "block", time_ns,
 		block_order);

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -134,66 +134,71 @@ static inline void check_sector(char *sector, uint64_t expected_offset,
 		&found_offset, 0, &stats->secs);
 }
 
-static uint64_t check_buffer(char *buf, size_t size, uint64_t expected_offset,
-	struct file_stats *stats)
+static void check_buffer(char *buf, uint64_t sectors,
+	uint64_t *pexpected_offset, struct file_stats *stats)
 {
-	char *beyond_buf = buf + size;
-
-	assert(size % SECTOR_SIZE == 0);
-
-	while (buf < beyond_buf) {
-		check_sector(buf, expected_offset, stats);
+	uint64_t i;
+	for (i = 0; i < sectors; i++) {
+		check_sector(buf, *pexpected_offset, stats);
 		buf += SECTOR_SIZE;
-		expected_offset += SECTOR_SIZE;
+		*pexpected_offset += SECTOR_SIZE;
 	}
-	return expected_offset;
 }
 
-static ssize_t read_all(int fd, char *buf, size_t count)
+static int read_all(int fd, char *buf, size_t *pbytes)
 {
+	ssize_t rc;
 	size_t done = 0;
 	do {
-		ssize_t rc = read(fd, buf + done, count - done);
+		rc = read(fd, buf + done, *pbytes - done);
 		if (rc < 0) {
 			if (errno == EINTR)
 				continue;
-			return - errno;
+			rc = errno;
+			goto out;
 		}
 		if (rc == 0)
-			break;
+			goto out;
 		done += rc;
-	} while (done < count);
-	return done;
+	} while (done < *pbytes);
+	rc = 0;
+
+out:
+	*pbytes = done;
+	return rc;
 }
 
-static ssize_t check_chunk(struct dynamic_buffer *dbuf, int fd,
-	uint64_t *p_expected_offset, uint64_t chunk_size,
-	struct file_stats *stats)
+static int check_chunk(struct flow *fw, struct dynamic_buffer *dbuf,
+	int fd, uint64_t *pexpected_offset, struct file_stats *stats,
+	size_t *ptot_bytes_read)
 {
+	uint64_t chunk_size = get_rem_chunk_blocks(fw) <<
+		fw_get_block_order(fw);
 	size_t len = chunk_size;
-	char *buf = dbuf_get_buf(dbuf, 0, &len);
-	ssize_t tot_bytes_read = 0;
+	char * const buf = dbuf_get_buf(dbuf, 0, &len);
+	size_t tot_bytes_read = 0;
+	int rc = 0;
 
 	while (chunk_size > 0) {
-		size_t turn_size = chunk_size <= len ? chunk_size : len;
-		ssize_t bytes_read = read_all(fd, buf, turn_size);
-
-		if (bytes_read < 0) {
-			stats->bytes_read += tot_bytes_read;
-			return bytes_read;
-		}
+		size_t bytes_read = MIN(chunk_size, len);
+		rc = read_all(fd, buf, &bytes_read);
+		tot_bytes_read += bytes_read;
 
 		if (bytes_read == 0)
 			break;
 
-		tot_bytes_read += bytes_read;
 		chunk_size -= bytes_read;
-		*p_expected_offset = check_buffer(buf, bytes_read,
-			*p_expected_offset, stats);
+		assert((bytes_read & (SECTOR_SIZE - 1)) == 0);
+		check_buffer(buf, bytes_read >> SECTOR_ORDER,
+			pexpected_offset, stats);
+
+		if (rc != 0)
+			break;
 	}
 
 	stats->bytes_read += tot_bytes_read;
-	return tot_bytes_read;
+	*ptot_bytes_read = tot_bytes_read;
+	return rc;
 }
 
 static inline void print_status(const struct file_stats *stats)
@@ -203,16 +208,15 @@ static inline void print_status(const struct file_stats *stats)
 		stats->secs.overwritten);
 }
 
-static void validate_file(const char *path, uint64_t number, struct flow *fw,
-	struct file_stats *stats)
+static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
+	const char *path, uint64_t number, struct file_stats *stats)
 {
+	const int block_size = fw_get_block_size(fw);
 	const int block_order = fw_get_block_order(fw);
 	char *full_fn;
 	const char *filename;
 	int fd, saved_errno;
-	ssize_t bytes_read;
 	uint64_t expected_offset;
-	struct dynamic_buffer dbuf;
 
 	zero_fstats(stats);
 
@@ -249,35 +253,36 @@ static void validate_file(const char *path, uint64_t number, struct flow *fw,
 	/* Help the kernel to help us. */
 	assert(!posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL));
 
-	dbuf_init(&dbuf);
 	saved_errno = 0;
 	expected_offset = number << GIGABYTE_ORDER;
 	start_measurement(fw);
 	while (true) {
-		bytes_read = check_chunk(&dbuf, fd, &expected_offset,
-			get_rem_chunk_blocks(fw) << block_order, stats);
-		if (bytes_read == 0)
-			break;
-		if (bytes_read < 0) {
-			saved_errno = - bytes_read;
+		size_t bytes_read;
+		int rc = check_chunk(fw, dbuf, fd, &expected_offset, stats,
+			&bytes_read);
+		if (rc == 0 && bytes_read == 0) {
+			stats->read_all = true;
 			break;
 		}
+		assert((bytes_read & (block_size - 1)) == 0);
 		measure(fw, bytes_read >> block_order);
+		if (rc != 0) {
+			saved_errno = rc;
+			break;
+		}
 	}
 	end_measurement(fw);
 
 	print_status(stats);
-	stats->read_all = bytes_read == 0;
 	if (!stats->read_all) {
-		assert(saved_errno);
+		assert(saved_errno != 0);
 		printf(" - NOT fully read due to \"%s\"",
 			strerror(saved_errno));
-	} else if (saved_errno) {
+	} else if (saved_errno != 0) {
 		printf(" - %s", strerror(saved_errno));
 	}
 	printf("\n");
 
-	dbuf_free(&dbuf);
 	close(fd);
 	free(full_fn);
 }
@@ -321,14 +326,15 @@ static void iterate_files(const char *path, const uint64_t *files,
 	int or_missing_file = 0;
 	uint64_t number = start_at;
 	struct flow fw;
+	struct dynamic_buffer dbuf;
 
 	UNUSED(end_at);
 
 	init_flow(&fw, block_size, get_total_blocks(path, files, block_size),
 		max_read_rate, progress ? printf_flush_cb : dummy_cb, 0);
-	printf("                  SECTORS "
-		"     ok/corrupted/changed/overwritten\n");
+	dbuf_init(&dbuf);
 
+	printf("                  SECTORS      ok/corrupted/changed/overwritten\n");
 	while (*files != (uint64_t)-1) {
 		struct file_stats stats;
 
@@ -343,7 +349,7 @@ static void iterate_files(const char *path, const uint64_t *files,
 		}
 		number++;
 
-		validate_file(path, *files, &fw, &stats);
+		validate_file(&fw, &dbuf, path, *files, &stats);
 		tot_stats.ok += stats.secs.ok;
 		tot_stats.bad += stats.secs.bad;
 		tot_stats.changed += stats.secs.changed;
@@ -352,9 +358,8 @@ static void iterate_files(const char *path, const uint64_t *files,
 		and_read_all = and_read_all && stats.read_all;
 		files++;
 	}
-	assert(tot_size == SECTOR_SIZE *
-		(tot_stats.ok + tot_stats.bad + tot_stats.changed
-			+ tot_stats.overwritten));
+	assert((tot_stats.ok + tot_stats.bad + tot_stats.changed +
+		tot_stats.overwritten) << SECTOR_ORDER == tot_size);
 
 	/* Notice that not reporting `missing' files after the last file
 	 * in @files is important since @end_at could be very large.
@@ -369,6 +374,8 @@ static void iterate_files(const char *path, const uint64_t *files,
 
 	/* Reading speed. */
 	print_avg_seq_speed(&fw, "read", true);
+
+	dbuf_free(&dbuf);
 }
 
 int main(int argc, char **argv)

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -261,16 +261,12 @@ static void validate_file(const char *path, uint64_t number, struct flow *fw,
 			saved_errno = - bytes_read;
 			break;
 		}
-		if (measure(fd, fw, bytes_read) < 0) {
+		if (measure(fw, bytes_read) < 0) {
 			saved_errno = errno;
 			break;
 		}
 	}
-	if (end_measurement(fd, fw) < 0) {
-		/* If a write failure has happened before, preserve it. */
-		if (!saved_errno)
-			saved_errno = errno;
-	}
+	end_measurement(fw);
 
 	print_status(stats);
 	stats->read_all = bytes_read == 0;
@@ -327,7 +323,7 @@ static void iterate_files(const char *path, const uint64_t *files,
 	UNUSED(end_at);
 
 	init_flow(&fw, get_block_size(path), get_total_size(path, files),
-		max_read_rate, progress ? printf_flush_cb : dummy_cb, 0, NULL);
+		max_read_rate, progress ? printf_flush_cb : dummy_cb, 0);
 	printf("                  SECTORS "
 		"     ok/corrupted/changed/overwritten\n");
 

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -284,9 +284,11 @@ static void validate_file(const char *path, uint64_t number, struct flow *fw,
 	free(full_fn);
 }
 
-static uint64_t get_total_size(const char *path, const uint64_t *files)
+static uint64_t get_total_blocks(const char *path, const uint64_t *files,
+	int block_size)
 {
-	uint64_t total_size = 0;
+	const int block_order = ilog2(block_size);
+	uint64_t total_blocks = 0;
 
 	while (*files != (uint64_t)-1) {
 		struct stat st;
@@ -300,20 +302,22 @@ static uint64_t get_total_size(const char *path, const uint64_t *files)
 			err(errno, "Can't stat file %s", full_fn);
 		if ((st.st_mode & S_IFMT) != S_IFREG)
 			err(EINVAL, "File %s is not a regular file", full_fn);
-		assert(st.st_size >= 0);
-		total_size += st.st_size;
+
+		assert((st.st_size & (block_size - 1)) == 0);
+		total_blocks += st.st_size >> block_order;
 
 		free(full_fn);
 		files++;
 	}
-	return total_size;
+	return total_blocks;
 }
 
 static void iterate_files(const char *path, const uint64_t *files,
 	uint64_t start_at, uint64_t end_at, uint64_t max_read_rate,
 	int progress)
 {
-	struct block_stats tot_stats = { 0, 0, 0, 0 };
+	const int block_size = get_block_size(path);
+	struct block_stats tot_stats = {0, 0, 0, 0};
 	uint64_t tot_size = 0;
 	int and_read_all = 1;
 	int or_missing_file = 0;
@@ -322,7 +326,7 @@ static void iterate_files(const char *path, const uint64_t *files,
 
 	UNUSED(end_at);
 
-	init_flow(&fw, get_block_size(path), get_total_size(path, files),
+	init_flow(&fw, block_size, get_total_blocks(path, files, block_size),
 		max_read_rate, progress ? printf_flush_cb : dummy_cb, 0);
 	printf("                  SECTORS "
 		"     ok/corrupted/changed/overwritten\n");

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -288,9 +288,9 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 }
 
 static uint64_t get_total_blocks(const char *path, const uint64_t *files,
-	unsigned int block_size)
+	unsigned int block_order)
 {
-	const unsigned int block_order = ilog2(block_size);
+	const unsigned int block_size = 1U << block_order;
 	uint64_t total_blocks = 0;
 
 	while (*files != (uint64_t)-1) {
@@ -319,7 +319,7 @@ static void iterate_files(const char *path, const uint64_t *files,
 	uint64_t start_at, uint64_t end_at, uint64_t max_read_rate,
 	int progress)
 {
-	const unsigned int block_size = get_block_size(path);
+	const unsigned int block_order = get_block_order(path);
 	struct block_stats tot_stats = {0, 0, 0, 0};
 	uint64_t tot_size = 0;
 	int and_read_all = 1;
@@ -330,7 +330,7 @@ static void iterate_files(const char *path, const uint64_t *files,
 
 	UNUSED(end_at);
 
-	init_flow(&fw, block_size, get_total_blocks(path, files, block_size),
+	init_flow(&fw, block_order, get_total_blocks(path, files, block_order),
 		max_read_rate, progress ? printf_flush_cb : dummy_cb, 0);
 	dbuf_init(&dbuf);
 
@@ -365,7 +365,7 @@ static void iterate_files(const char *path, const uint64_t *files,
 	 * in @files is important since @end_at could be very large.
 	 */
 
-	print_stats(&tot_stats, SECTOR_SIZE, "sector");
+	print_stats(&tot_stats, SECTOR_ORDER, "sector");
 	if (or_missing_file)
 		printf("WARNING: Not all F3 files in the range %" PRIu64 " to %" PRIu64 " are available\n",
 			start_at + 1, number);

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -170,8 +170,8 @@ static ssize_t check_chunk(struct dynamic_buffer *dbuf, int fd,
 	uint64_t *p_expected_offset, uint64_t chunk_size,
 	struct file_stats *stats)
 {
-	char *buf = dbuf_get_buf(dbuf, chunk_size);
-	size_t len = dbuf_get_len(dbuf);
+	size_t len = chunk_size;
+	char *buf = dbuf_get_buf(dbuf, 0, &len);
 	ssize_t tot_bytes_read = 0;
 
 	while (chunk_size > 0) {

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -211,8 +211,8 @@ static inline void print_status(const struct file_stats *stats)
 static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 	const char *path, uint64_t number, struct file_stats *stats)
 {
-	const int block_size = fw_get_block_size(fw);
-	const int block_order = fw_get_block_order(fw);
+	const unsigned int block_size = fw_get_block_size(fw);
+	const unsigned int block_order = fw_get_block_order(fw);
 	char *full_fn;
 	const char *filename;
 	int fd, saved_errno;
@@ -288,9 +288,9 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 }
 
 static uint64_t get_total_blocks(const char *path, const uint64_t *files,
-	int block_size)
+	unsigned int block_size)
 {
-	const int block_order = ilog2(block_size);
+	const unsigned int block_order = ilog2(block_size);
 	uint64_t total_blocks = 0;
 
 	while (*files != (uint64_t)-1) {
@@ -319,7 +319,7 @@ static void iterate_files(const char *path, const uint64_t *files,
 	uint64_t start_at, uint64_t end_at, uint64_t max_read_rate,
 	int progress)
 {
-	const int block_size = get_block_size(path);
+	const unsigned int block_size = get_block_size(path);
 	struct block_stats tot_stats = {0, 0, 0, 0};
 	uint64_t tot_size = 0;
 	int and_read_all = 1;

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -206,6 +206,7 @@ static inline void print_status(const struct file_stats *stats)
 static void validate_file(const char *path, uint64_t number, struct flow *fw,
 	struct file_stats *stats)
 {
+	const int block_order = fw_get_block_order(fw);
 	char *full_fn;
 	const char *filename;
 	int fd, saved_errno;
@@ -254,17 +255,14 @@ static void validate_file(const char *path, uint64_t number, struct flow *fw,
 	start_measurement(fw);
 	while (true) {
 		bytes_read = check_chunk(&dbuf, fd, &expected_offset,
-			get_rem_chunk_size(fw), stats);
+			get_rem_chunk_blocks(fw) << block_order, stats);
 		if (bytes_read == 0)
 			break;
 		if (bytes_read < 0) {
 			saved_errno = - bytes_read;
 			break;
 		}
-		if (measure(fw, bytes_read) < 0) {
-			saved_errno = errno;
-			break;
-		}
+		measure(fw, bytes_read >> block_order);
 	}
 	end_measurement(fw);
 

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -232,13 +232,6 @@ static int create_and_fill_file(const char *path, uint64_t number, size_t size,
 	return false;
 }
 
-static inline uint64_t get_freespace(const char *path)
-{
-	struct statvfs fs;
-	assert(!statvfs(path, &fs));
-	return (uint64_t)fs.f_frsize * (uint64_t)fs.f_bfree;
-}
-
 static inline void pr_freespace(uint64_t fs)
 {
 	double f = (double)fs;
@@ -249,34 +242,35 @@ static inline void pr_freespace(uint64_t fs)
 static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	uint64_t max_write_rate, int progress)
 {
-	uint64_t free_space;
+	const int block_size = get_block_size(path);
+	uint64_t free_blocks = get_free_blocks(path);
 	struct flow fw;
 	uint64_t i;
 	int has_suggested_max_write_rate = max_write_rate > 0;
 
-	free_space = get_freespace(path);
-	pr_freespace(free_space);
-	if (free_space <= 0) {
+	pr_freespace(free_blocks * block_size);
+	if (free_blocks == 0) {
 		printf("No space!\n");
 		return 1;
 	}
 
 	assert(start_at <= end_at);
 	i = end_at - start_at + 1;
-	if (i <= (free_space >> GIGABYTE_ORDER)) {
+	if (i <= (free_blocks * block_size >> GIGABYTE_ORDER)) {
 		/* The amount of data to write is less than the space available,
-		 * update free_space to improve estimate of time to finish.
+		 * update free_blocks to improve estimate of time to finish.
 		 */
-		free_space = i << GIGABYTE_ORDER;
+		free_blocks = (i << GIGABYTE_ORDER) / block_size;
 	} else {
 		/* There are more data to write than space available.
 		 * Reduce end_at to reduce the number of error messages
 		 * due to multiple write failures.
 		 */
-		end_at = start_at + (free_space >> GIGABYTE_ORDER);
+		end_at = start_at +
+			(free_blocks * block_size >> GIGABYTE_ORDER);
 	}
 
-	init_flow(&fw, get_block_size(path), free_space, max_write_rate,
+	init_flow(&fw, block_size, free_blocks, max_write_rate,
 		progress ? printf_flush_cb : dummy_cb, 0);
 	for (i = start_at; i <= end_at; i++)
 		if (create_and_fill_file(path, i, GIGABYTE_SIZE,
@@ -284,7 +278,7 @@ static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 			break;
 
 	/* Final report. */
-	pr_freespace(get_freespace(path));
+	pr_freespace(get_free_blocks(path) * block_size);
 	print_avg_seq_speed(&fw, "write", true);
 
 	return 0;

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -268,36 +268,37 @@ static inline void pr_freespace(uint64_t fs)
 static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	uint64_t max_write_rate, int progress)
 {
-	const unsigned int block_size = get_block_size(path);
+	const unsigned int block_order = get_block_order(path);
 	uint64_t free_blocks = get_free_blocks(path);
 	struct flow fw;
 	struct dynamic_buffer dbuf;
 	uint64_t i;
 	int has_suggested_max_write_rate = max_write_rate > 0;
 
-	pr_freespace(free_blocks * block_size);
+	pr_freespace(free_blocks << block_order);
 	if (free_blocks == 0) {
 		printf("No space!\n");
 		return 1;
 	}
 
 	assert(start_at <= end_at);
+	assert(GIGABYTE_ORDER >= block_order);
 	i = end_at - start_at + 1;
-	if (i <= (free_blocks * block_size >> GIGABYTE_ORDER)) {
+	if (i <= (free_blocks >> (GIGABYTE_ORDER - block_order))) {
 		/* The amount of data to write is less than the space available,
 		 * update free_blocks to improve estimate of time to finish.
 		 */
-		free_blocks = (i << GIGABYTE_ORDER) / block_size;
+		free_blocks = i << (GIGABYTE_ORDER - block_order);
 	} else {
 		/* There are more data to write than space available.
 		 * Reduce end_at to reduce the number of error messages
 		 * due to multiple write failures.
 		 */
 		end_at = start_at +
-			(free_blocks * block_size >> GIGABYTE_ORDER);
+			(free_blocks >> (GIGABYTE_ORDER - block_order));
 	}
 
-	init_flow(&fw, block_size, free_blocks, max_write_rate,
+	init_flow(&fw, block_order, free_blocks, max_write_rate,
 		progress ? printf_flush_cb : dummy_cb, 0);
 	dbuf_init(&dbuf);
 	for (i = start_at; i <= end_at; i++) {
@@ -308,7 +309,7 @@ static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	dbuf_free(&dbuf);
 
 	/* Final report. */
-	pr_freespace(get_free_blocks(path) * block_size);
+	pr_freespace(get_free_blocks(path) << block_order);
 	print_avg_seq_speed(&fw, "write", true);
 	return 0;
 }

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -131,8 +131,8 @@ static int write_all(int fd, const char *buf, size_t count)
 static int write_chunk(struct dynamic_buffer *dbuf, int fd, size_t chunk_size,
 	uint64_t *poffset)
 {
-	char *buf = dbuf_get_buf(dbuf, chunk_size);
-	size_t len = dbuf_get_len(dbuf);
+	size_t len = chunk_size;
+	char *buf = dbuf_get_buf(dbuf, 0, &len);
 
 	while (chunk_size > 0) {
 		size_t turn_size = chunk_size <= len ? chunk_size : len;

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -197,6 +197,14 @@ static int create_and_fill_file(const char *path, uint64_t number, size_t size,
 		if (saved_errno)
 			break;
 		remaining -= write_size;
+
+		/* Push data to drive and tip the kernel. */
+		if (fdatasync(fd) < 0) {
+			saved_errno = errno;
+			break;
+		}
+		assert(!posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED));
+
 		if (measure(fd, fw, write_size) < 0) {
 			saved_errno = errno;
 			break;
@@ -242,18 +250,6 @@ static inline void pr_freespace(uint64_t fs)
 	printf("Free space: %.2f %s\n", f, unit);
 }
 
-static int flush_chunk(const struct flow *fw, int fd)
-{
-	UNUSED(fw);
-
-	if (fdatasync(fd) < 0)
-		return -1; /* Caller can read errno(3). */
-
-	/* Help the kernel to help us. */
-	assert(!posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED));
-	return 0;
-}
-
 static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	uint64_t max_write_rate, int progress)
 {
@@ -285,7 +281,7 @@ static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	}
 
 	init_flow(&fw, get_block_size(path), free_space, max_write_rate,
-		progress ? printf_flush_cb : dummy_cb, 0, flush_chunk);
+		progress ? printf_flush_cb : dummy_cb, 0, NULL);
 	for (i = start_at; i <= end_at; i++)
 		if (create_and_fill_file(path, i, GIGABYTE_SIZE,
 			&has_suggested_max_write_rate, &fw))

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -205,16 +205,12 @@ static int create_and_fill_file(const char *path, uint64_t number, size_t size,
 		}
 		assert(!posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED));
 
-		if (measure(fd, fw, write_size) < 0) {
+		if (measure(fw, write_size) < 0) {
 			saved_errno = errno;
 			break;
 		}
 	}
-	if (end_measurement(fd, fw) < 0) {
-		/* If a write failure has happened before, preserve it. */
-		if (!saved_errno)
-			saved_errno = errno;
-	}
+	end_measurement(fw);
 	dbuf_free(&dbuf);
 	close(fd);
 	free(full_fn);
@@ -281,7 +277,7 @@ static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	}
 
 	init_flow(&fw, get_block_size(path), free_space, max_write_rate,
-		progress ? printf_flush_cb : dummy_cb, 0, NULL);
+		progress ? printf_flush_cb : dummy_cb, 0);
 	for (i = start_at; i <= end_at; i++)
 		if (create_and_fill_file(path, i, GIGABYTE_SIZE,
 			&has_suggested_max_write_rate, &fw))

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -2,6 +2,7 @@
 #define _XOPEN_SOURCE 600
 
 #include <assert.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -11,6 +12,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/statvfs.h>
+#include <sys/types.h>
 #include <errno.h>
 #include <unistd.h>
 #include <err.h>
@@ -113,57 +115,77 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 
 static struct argp argp = {options, parse_opt, adoc, doc, NULL, NULL, NULL};
 
-/* XXX Avoid duplicate this function, which was copied from libdevs.c. */
-static int write_all(int fd, const char *buf, size_t count)
+static void fill_buffer(char *buf, uint64_t sectors, uint64_t *poffset)
 {
-	size_t done = 0;
-	do {
-		ssize_t rc = write(fd, buf + done, count - done);
-		if (rc < 0) {
-			/* The write() failed. */
-			return errno;
-		}
-		done += rc;
-	} while (done < count);
-	return 0;
+	uint64_t i;
+	for (i = 0; i < sectors; i++) {
+		fill_buffer_with_block(buf, SECTOR_ORDER, *poffset, 0);
+		buf += SECTOR_SIZE;
+		*poffset += SECTOR_SIZE;
+	}
 }
 
-static int write_chunk(struct dynamic_buffer *dbuf, int fd, size_t chunk_size,
-	uint64_t *poffset)
+static int write_all(int fd, const char *buf, size_t *pbytes)
 {
+	ssize_t rc;
+	size_t done = 0;
+	do {
+		rc = write(fd, buf + done, *pbytes - done);
+		if (rc < 0) {
+			rc = errno;
+			goto out;
+		}
+		done += rc;
+	} while (done < *pbytes);
+	rc = 0;
+
+out:
+	*pbytes = done;
+	return rc;
+}
+
+static int write_chunk(struct flow *fw, struct dynamic_buffer *dbuf,
+	int fd, uint64_t remaining_blocks, uint64_t *poffset,
+	size_t *ptot_bytes_written)
+{
+	int rc = 0;
+	uint64_t chunk_size = MIN(get_rem_chunk_blocks(fw), remaining_blocks)
+		<< fw_get_block_order(fw);
 	size_t len = chunk_size;
-	char *buf = dbuf_get_buf(dbuf, 0, &len);
+	char * const buf = dbuf_get_buf(dbuf, 0, &len);
+	size_t tot_bytes_written = 0;
 
 	while (chunk_size > 0) {
-		size_t turn_size = chunk_size <= len ? chunk_size : len;
-		size_t i;
-		int ret;
+		const size_t turn_size = MIN(chunk_size, len);
+		size_t bytes_written = turn_size;
 
+		assert((turn_size & (SECTOR_SIZE - 1)) == 0);
+		fill_buffer(buf, turn_size >> SECTOR_ORDER, poffset);
+
+		rc = write_all(fd, buf, &bytes_written);
+		tot_bytes_written += bytes_written;
+		if (rc != 0)
+			goto out;
+		assert(bytes_written == turn_size);
 		chunk_size -= turn_size;
-		for (i = 0; i < turn_size; i += SECTOR_SIZE) {
-			fill_buffer_with_block(buf + i, SECTOR_ORDER, *poffset, 0);
-			*poffset += SECTOR_SIZE;
-		}
-
-		ret = write_all(fd, buf, turn_size);
-		if (ret)
-			return ret;
 	}
 
-	return 0;
+out:
+	*ptot_bytes_written = tot_bytes_written;
+	return rc;
 }
 
 /* Return true when disk is full. */
-static int create_and_fill_file(const char *path, uint64_t number,
-	int *phas_suggested_max_write_rate, struct flow *fw)
+static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
+	const char *path, uint64_t number, int *phas_suggested_max_write_rate)
 {
+	const int block_size = fw_get_block_size(fw);
 	const int block_order = fw_get_block_order(fw);
 	uint64_t remaining_blocks = 1ULL << (GIGABYTE_ORDER - block_order);
 	char *full_fn;
 	const char *filename;
 	int fd, saved_errno;
 	uint64_t offset;
-	struct dynamic_buffer dbuf;
 
 	assert(GIGABYTE_ORDER >= block_order);
 
@@ -184,30 +206,38 @@ static int create_and_fill_file(const char *path, uint64_t number,
 	assert(fd >= 0);
 
 	/* Write content. */
-	dbuf_init(&dbuf);
 	saved_errno = 0;
 	offset = number << GIGABYTE_ORDER;
 	start_measurement(fw);
 	while (remaining_blocks > 0) {
-		uint64_t write_blocks =
-			MIN(get_rem_chunk_blocks(fw), remaining_blocks);
-		saved_errno = write_chunk(&dbuf, fd,
-			write_blocks << block_order, &offset);
-		if (saved_errno)
+		size_t bytes_written;
+		uint64_t written_blocks;
+
+		saved_errno = write_chunk(fw, dbuf, fd, remaining_blocks,
+			&offset, &bytes_written);
+		if (bytes_written == 0)
 			break;
-		remaining_blocks -= write_blocks;
 
 		/* Push data to drive and tip the kernel. */
 		if (fdatasync(fd) < 0) {
-			saved_errno = errno;
-			break;
+			/* Preserve the first error. */
+			if (saved_errno == 0)
+				saved_errno = errno;
 		}
-		assert(!posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED));
+		if (saved_errno == 0) {
+			saved_errno = posix_fadvise(fd, 0, 0,
+				POSIX_FADV_DONTNEED);
+		}
 
-		measure(fw, write_blocks);
+		assert((bytes_written & (block_size - 1)) == 0);
+		written_blocks = bytes_written >> block_order;
+		measure(fw, written_blocks);
+		remaining_blocks -= written_blocks;
+
+		if (saved_errno != 0)
+			break;
 	}
 	end_measurement(fw);
-	dbuf_free(&dbuf);
 	close(fd);
 	free(full_fn);
 
@@ -219,7 +249,7 @@ static int create_and_fill_file(const char *path, uint64_t number,
 	}
 
 	/* Something went wrong. */
-	assert(saved_errno);
+	assert(saved_errno != 0);
 	printf("Write failure: %s\n", strerror(saved_errno));
 	if (saved_errno == EIO && !*phas_suggested_max_write_rate) {
 		*phas_suggested_max_write_rate = true;
@@ -241,6 +271,7 @@ static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	const int block_size = get_block_size(path);
 	uint64_t free_blocks = get_free_blocks(path);
 	struct flow fw;
+	struct dynamic_buffer dbuf;
 	uint64_t i;
 	int has_suggested_max_write_rate = max_write_rate > 0;
 
@@ -268,15 +299,17 @@ static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 
 	init_flow(&fw, block_size, free_blocks, max_write_rate,
 		progress ? printf_flush_cb : dummy_cb, 0);
-	for (i = start_at; i <= end_at; i++)
-		if (create_and_fill_file(path, i,
-			&has_suggested_max_write_rate, &fw))
+	dbuf_init(&dbuf);
+	for (i = start_at; i <= end_at; i++) {
+		if (create_and_fill_file(&fw, &dbuf, path, i,
+				&has_suggested_max_write_rate))
 			break;
+	}
+	dbuf_free(&dbuf);
 
 	/* Final report. */
 	pr_freespace(get_free_blocks(path) * block_size);
 	print_avg_seq_speed(&fw, "write", true);
-
 	return 0;
 }
 

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -179,8 +179,8 @@ out:
 static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 	const char *path, uint64_t number, int *phas_suggested_max_write_rate)
 {
-	const int block_size = fw_get_block_size(fw);
-	const int block_order = fw_get_block_order(fw);
+	const unsigned int block_size = fw_get_block_size(fw);
+	const unsigned int block_order = fw_get_block_order(fw);
 	uint64_t remaining_blocks = 1ULL << (GIGABYTE_ORDER - block_order);
 	char *full_fn;
 	const char *filename;
@@ -268,7 +268,7 @@ static inline void pr_freespace(uint64_t fs)
 static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	uint64_t max_write_rate, int progress)
 {
-	const int block_size = get_block_size(path);
+	const unsigned int block_size = get_block_size(path);
 	uint64_t free_blocks = get_free_blocks(path);
 	struct flow fw;
 	struct dynamic_buffer dbuf;

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -154,18 +154,18 @@ static int write_chunk(struct dynamic_buffer *dbuf, int fd, size_t chunk_size,
 }
 
 /* Return true when disk is full. */
-static int create_and_fill_file(const char *path, uint64_t number, size_t size,
+static int create_and_fill_file(const char *path, uint64_t number,
 	int *phas_suggested_max_write_rate, struct flow *fw)
 {
+	const int block_order = fw_get_block_order(fw);
+	uint64_t remaining_blocks = 1ULL << (GIGABYTE_ORDER - block_order);
 	char *full_fn;
 	const char *filename;
 	int fd, saved_errno;
-	size_t remaining;
 	uint64_t offset;
 	struct dynamic_buffer dbuf;
 
-	assert(size > 0);
-	assert(size % fw_get_block_size(fw) == 0);
+	assert(GIGABYTE_ORDER >= block_order);
 
 	/* Create the file. */
 	full_fn = full_fn_from_number(&filename, path, number);
@@ -187,16 +187,15 @@ static int create_and_fill_file(const char *path, uint64_t number, size_t size,
 	dbuf_init(&dbuf);
 	saved_errno = 0;
 	offset = number << GIGABYTE_ORDER;
-	remaining = size;
 	start_measurement(fw);
-	while (remaining > 0) {
-		uint64_t write_size = get_rem_chunk_size(fw);
-		if (write_size > remaining)
-			write_size = remaining;
-		saved_errno = write_chunk(&dbuf, fd, write_size, &offset);
+	while (remaining_blocks > 0) {
+		uint64_t write_blocks =
+			MIN(get_rem_chunk_blocks(fw), remaining_blocks);
+		saved_errno = write_chunk(&dbuf, fd,
+			write_blocks << block_order, &offset);
 		if (saved_errno)
 			break;
-		remaining -= write_size;
+		remaining_blocks -= write_blocks;
 
 		/* Push data to drive and tip the kernel. */
 		if (fdatasync(fd) < 0) {
@@ -205,10 +204,7 @@ static int create_and_fill_file(const char *path, uint64_t number, size_t size,
 		}
 		assert(!posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED));
 
-		if (measure(fw, write_size) < 0) {
-			saved_errno = errno;
-			break;
-		}
+		measure(fw, write_blocks);
 	}
 	end_measurement(fw);
 	dbuf_free(&dbuf);
@@ -217,7 +213,7 @@ static int create_and_fill_file(const char *path, uint64_t number, size_t size,
 
 	if (saved_errno == 0 || saved_errno == ENOSPC) {
 		if (saved_errno == 0)
-			assert(remaining == 0);
+			assert(remaining_blocks == 0);
 		printf("OK!\n");
 		return saved_errno == ENOSPC;
 	}
@@ -273,7 +269,7 @@ static int fill_fs(const char *path, uint64_t start_at, uint64_t end_at,
 	init_flow(&fw, block_size, free_blocks, max_write_rate,
 		progress ? printf_flush_cb : dummy_cb, 0);
 	for (i = start_at; i <= end_at; i++)
-		if (create_and_fill_file(path, i, GIGABYTE_SIZE,
+		if (create_and_fill_file(path, i,
 			&has_suggested_max_write_rate, &fw))
 			break;
 

--- a/src/libdevs.c
+++ b/src/libdevs.c
@@ -49,7 +49,8 @@ int dev_param_valid(uint64_t real_size_byte,
 
 	/* Check alignment of the sizes. */
 	block_size = 1 << block_order;
-	if (real_size_byte % block_size || announced_size_byte % block_size)
+	if ((real_size_byte & (block_size - 1)) != 0 ||
+			(announced_size_byte & (block_size - 1)) != 0)
 		return false;
 
 	/* If good, @wrap must make sense. */
@@ -535,15 +536,15 @@ static struct udev_monitor *create_monitor(struct udev *udev,
 
 static uint64_t get_udev_dev_size_byte(struct udev_device *dev)
 {
-	const char *str_size_sector =
+	const char *str_size_sectors =
 		udev_device_get_sysattr_value(dev, "size");
 	char *end;
-	long long size_sector;
-	if (!str_size_sector)
+	long long size_sectors;
+	if (str_size_sectors == NULL)
 		return 0;
-	size_sector = strtoll(str_size_sector, &end, 10);
-	assert(!*end);
-	return size_sector * 512LL;
+	size_sectors = strtoll(str_size_sectors, &end, 10);
+	assert(*end == '\0');
+	return size_sectors << SECTOR_ORDER;
 }
 
 static int wait_for_reset(struct udev *udev, const char *id_serial,
@@ -1356,8 +1357,8 @@ struct device *create_safe_device(struct device *dev, uint64_t max_blocks,
 	int min_memory)
 {
 	struct safe_device *sdev;
-	const int block_order = dev_get_block_order(dev);
 	const int block_size = dev_get_block_size(dev);
+	const int block_order = dev_get_block_order(dev);
 	uint64_t length;
 
 	sdev = malloc(sizeof(*sdev));

--- a/src/libdevs.c
+++ b/src/libdevs.c
@@ -38,9 +38,9 @@ const char *fake_type_to_name(enum fake_type fake_type)
 }
 
 int dev_param_valid(uint64_t real_size_byte,
-	uint64_t announced_size_byte, int wrap, int block_order)
+	uint64_t announced_size_byte, int wrap, unsigned int block_order)
 {
-	int block_size;
+	unsigned int block_size;
 
 	/* Check general ranges. */
 	if (real_size_byte > announced_size_byte || wrap < 0 || wrap >= 64 ||
@@ -62,7 +62,7 @@ int dev_param_valid(uint64_t real_size_byte,
 }
 
 enum fake_type dev_param_to_type(uint64_t real_size_byte,
-	uint64_t announced_size_byte, int wrap, int block_order)
+	uint64_t announced_size_byte, int wrap, unsigned int block_order)
 {
 	uint64_t two_wrap;
 
@@ -87,7 +87,7 @@ enum fake_type dev_param_to_type(uint64_t real_size_byte,
 
 struct device {
 	uint64_t	size_byte;
-	int		block_order;
+	unsigned int	block_order;
 
 	int (*read_blocks)(struct device *dev, char *buf,
 		uint64_t first_pos, uint64_t last_pos);
@@ -103,14 +103,14 @@ uint64_t dev_get_size_byte(const struct device *dev)
 	return dev->size_byte;
 }
 
-int dev_get_block_order(const struct device *dev)
+unsigned int dev_get_block_order(const struct device *dev)
 {
 	return dev->block_order;
 }
 
-int dev_get_block_size(const struct device *dev)
+unsigned int dev_get_block_size(const struct device *dev)
 {
-	return 1 << dev->block_order;
+	return 1U << dev->block_order;
 }
 
 const char *dev_get_filename(struct device *dev)
@@ -169,10 +169,10 @@ static inline struct file_device *dev_fdev(struct device *dev)
 static int fdev_read_block(struct device *dev, char *buf, uint64_t block_pos)
 {
 	struct file_device *fdev = dev_fdev(dev);
-	const int block_size = dev_get_block_size(dev);
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	off_t off_ret, offset = block_pos << block_order;
-	int done;
+	unsigned int done;
 
 	offset &= fdev->address_mask;
 	if ((uint64_t)offset >= fdev->real_size_byte) {
@@ -220,7 +220,7 @@ no_block:
 static int fdev_read_blocks(struct device *dev, char *buf,
 		uint64_t first_pos, uint64_t last_pos)
 {
-	const int block_size = dev_get_block_size(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
 	uint64_t pos;
 
 	for (pos = first_pos; pos <= last_pos; pos++) {
@@ -250,8 +250,8 @@ static int fdev_write_block(struct device *dev, const char *buf,
 	uint64_t block_pos)
 {
 	struct file_device *fdev = dev_fdev(dev);
-	const int block_size = dev_get_block_size(dev);
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	off_t off_ret, offset = block_pos << block_order;
 
 	offset &= fdev->address_mask;
@@ -282,7 +282,7 @@ static int fdev_write_block(struct device *dev, const char *buf,
 static int fdev_write_blocks(struct device *dev, const char *buf,
 		uint64_t first_pos, uint64_t last_pos)
 {
-	const int block_size = dev_get_block_size(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
 	uint64_t pos;
 
 	for (pos = first_pos; pos <= last_pos; pos++) {
@@ -310,7 +310,7 @@ static const char *fdev_get_filename(struct device *dev)
 
 struct device *create_file_device(const char *filename,
 	uint64_t real_size_byte, uint64_t fake_size_byte, int wrap,
-	int block_order, int cache_order, int strict_cache,
+	unsigned int block_order, int cache_order, int strict_cache,
 	int keep_file)
 {
 	struct file_device *fdev;
@@ -359,8 +359,8 @@ struct device *create_file_device(const char *filename,
 		blksize_t block_size;
 		assert(!fstat(fdev->fd, &fd_stat));
 		block_size = fd_stat.st_blksize;
+		assert(is_power_of_2(block_size));
 		block_order = ilog2(block_size);
-		assert(block_size == (1 << block_order));
 	}
 
 	if (!dev_param_valid(real_size_byte, fake_size_byte, wrap, block_order))
@@ -437,7 +437,7 @@ static int bdev_read_blocks(struct device *dev, char *buf,
 		uint64_t first_pos, uint64_t last_pos)
 {
 	struct block_device *bdev = dev_bdev(dev);
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	size_t length = (last_pos - first_pos + 1) << block_order;
 	off_t offset = first_pos << block_order;
 	off_t off_ret = lseek(bdev->fd, offset, SEEK_SET);
@@ -451,7 +451,7 @@ static int bdev_write_blocks(struct device *dev, const char *buf,
 		uint64_t first_pos, uint64_t last_pos)
 {
 	struct block_device *bdev = dev_bdev(dev);
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	size_t length = (last_pos - first_pos + 1) << block_order;
 	off_t offset = first_pos << block_order;
 	off_t off_ret = lseek(bdev->fd, offset, SEEK_SET);

--- a/src/libdevs.h
+++ b/src/libdevs.h
@@ -29,10 +29,10 @@ enum fake_type {
 const char *fake_type_to_name(enum fake_type fake_type);
 
 int dev_param_valid(uint64_t real_size_byte,
-	uint64_t announced_size_byte, int wrap, int block_order);
+	uint64_t announced_size_byte, int wrap, unsigned int block_order);
 
 enum fake_type dev_param_to_type(uint64_t real_size_byte,
-	uint64_t announced_size_byte, int wrap, int block_order);
+	uint64_t announced_size_byte, int wrap, unsigned int block_order);
 
 /*
  *	Abstract device
@@ -45,8 +45,8 @@ struct device;
  */
 
 uint64_t dev_get_size_byte(const struct device *dev);
-int dev_get_block_order(const struct device *dev);
-int dev_get_block_size(const struct device *dev);
+unsigned int dev_get_block_order(const struct device *dev);
+unsigned int dev_get_block_size(const struct device *dev);
 /* File name of the device.
  * This information is important because the filename may change due to resets.
  */
@@ -70,7 +70,7 @@ void free_device(struct device *dev);
 
 struct device *create_file_device(const char *filename,
 	uint64_t real_size_byte, uint64_t fake_size_byte, int wrap,
-	int block_order, int cache_order, int strict_cache,
+	unsigned int block_order, int cache_order, int strict_cache,
 	int keep_file);
 
 enum reset_type {

--- a/src/libfile.c
+++ b/src/libfile.c
@@ -45,6 +45,13 @@ int get_block_size(const char *path)
 	return fs.f_frsize;
 }
 
+uint64_t get_free_blocks(const char *path)
+{
+	struct statvfs fs;
+	assert(!statvfs(path, &fs));
+	return fs.f_bfree;
+}
+
 int is_my_file(const char *filename)
 {
 	const char *p = filename;

--- a/src/libfile.c
+++ b/src/libfile.c
@@ -23,6 +23,7 @@
 #include <sys/statvfs.h>
 
 #include "libfile.h"
+#include "libutils.h"
 
 void adjust_dev_path(const char **dev_path)
 {
@@ -38,11 +39,15 @@ void adjust_dev_path(const char **dev_path)
 	}
 }
 
-unsigned int get_block_size(const char *path)
+unsigned int get_block_order(const char *path)
 {
 	struct statvfs fs;
+	unsigned int block_size;
+
 	assert(!statvfs(path, &fs));
-	return fs.f_frsize;
+	block_size = fs.f_frsize;
+	assert(is_power_of_2(block_size));
+	return ilog2(block_size);
 }
 
 uint64_t get_free_blocks(const char *path)

--- a/src/libfile.c
+++ b/src/libfile.c
@@ -38,7 +38,7 @@ void adjust_dev_path(const char **dev_path)
 	}
 }
 
-int get_block_size(const char *path)
+unsigned int get_block_size(const char *path)
 {
 	struct statvfs fs;
 	assert(!statvfs(path, &fs));

--- a/src/libfile.h
+++ b/src/libfile.h
@@ -6,6 +6,7 @@
 void adjust_dev_path(const char **dev_path);
 
 int get_block_size(const char *path);
+uint64_t get_free_blocks(const char *path);
 
 /* Return true if @filename matches the regex /^[0-9]+\.h2w$/ */
 int is_my_file(const char *filename);

--- a/src/libfile.h
+++ b/src/libfile.h
@@ -5,7 +5,7 @@
 
 void adjust_dev_path(const char **dev_path);
 
-int get_block_size(const char *path);
+unsigned int get_block_size(const char *path);
 uint64_t get_free_blocks(const char *path);
 
 /* Return true if @filename matches the regex /^[0-9]+\.h2w$/ */

--- a/src/libfile.h
+++ b/src/libfile.h
@@ -5,7 +5,7 @@
 
 void adjust_dev_path(const char **dev_path);
 
-unsigned int get_block_size(const char *path);
+unsigned int get_block_order(const char *path);
 uint64_t get_free_blocks(const char *path);
 
 /* Return true if @filename matches the regex /^[0-9]+\.h2w$/ */

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -65,15 +65,15 @@ static inline void move_to_inc_at_start(struct flow *fw)
 	fw->state = FW_INC;
 }
 
-void init_flow(struct flow *fw, unsigned int block_size, uint64_t total_blocks,
+void init_flow(struct flow *fw, unsigned int block_order, uint64_t total_blocks,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent)
 {
 	fw->total_blocks		= total_blocks;
 	fw->cb				= cb;
 	fw->indent			= indent;
-	fw->block_size			= block_size; /* Bytes		*/
-	fw->blocks_per_delay		= 1;	/* block_size B/s	*/
-	fw->delay_ns			= 1000000000ULL;	/* 1s	*/
+	fw->block_order			= block_order;
+	fw->blocks_per_delay		= 1;
+	fw->delay_ns			= 1000000000ULL; /* 1s */
 	fw->max_process_rate		= max_process_rate == 0
 		? DBL_MAX : max_process_rate * 1024.;
 	fw->measured_blocks		= 0;
@@ -84,8 +84,7 @@ void init_flow(struct flow *fw, unsigned int block_size, uint64_t total_blocks,
 	fw->rem_chunk_speed		= 0;
 	fw->processed_blocks		= 0;
 	fw->acc_delay_ns		= 0;
-	assert(fw->block_size > 0);
-	assert(fw->block_size % SECTOR_SIZE == 0);
+	assert(fw->block_order >= SECTOR_ORDER);
 
 	move_to_inc_at_start(fw);
 }
@@ -204,7 +203,7 @@ void start_measurement(struct flow *fw)
 	 * multiple files; this happens when a drive is faster than 1GB/s.
 	 */
 	report_progress(fw,
-		fw->blocks_per_delay * fw->block_size * 1000000000.0 /
+		(fw->blocks_per_delay << fw->block_order) * 1000000000.0 /
 			fw->delay_ns);
 	__start_measurement(fw);
 }
@@ -296,7 +295,7 @@ void measure(struct flow *fw, uint64_t processed_blocks)
 
 	assert(!clock_gettime(CLOCK_MONOTONIC, &t2));
 	delay_ns = diff_timespec_ns(&fw->t1, &t2) + fw->acc_delay_ns;
-	bytes_g = fw->blocks_per_delay * fw->block_size * 1000000000.0;
+	bytes_g = (fw->blocks_per_delay << fw->block_order) * 1000000000.0;
 	/* Instantaneous speed in bytes per second. */
 	inst_speed = bytes_g / delay_ns;
 

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -65,7 +65,7 @@ static inline void move_to_inc_at_start(struct flow *fw)
 	fw->state = FW_INC;
 }
 
-void init_flow(struct flow *fw, int block_size, uint64_t total_blocks,
+void init_flow(struct flow *fw, unsigned int block_size, uint64_t total_blocks,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent)
 {
 	fw->total_blocks		= total_blocks;
@@ -459,7 +459,7 @@ void end_measurement(struct flow *fw)
 void print_avg_seq_speed(const struct flow *fw, const char *speed_type,
 	bool use_sectors)
 {
-	int block_order = fw_get_block_order(fw);
+	unsigned int block_order = fw_get_block_order(fw);
 	uint64_t blocks, time_ns;
 	char prefix[128];
 	int ret = snprintf(prefix, sizeof(prefix), "Average sequential %s speed:",
@@ -492,10 +492,10 @@ void dbuf_free(struct dynamic_buffer *dbuf)
 	dbuf->max_buf = true;
 }
 
-char *dbuf_get_buf(struct dynamic_buffer *dbuf, int align_order,
+char *dbuf_get_buf(struct dynamic_buffer *dbuf, unsigned int align_order,
 	size_t *psize)
 {
-	const int max_align_order = ilog2(alignof(max_align_t));
+	const unsigned int max_align_order = ilog2(alignof(max_align_t));
 	const size_t original_size = *psize;
 	size_t size = original_size;
 	size_t alignment, threshold;

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -65,10 +65,10 @@ static inline void move_to_inc_at_start(struct flow *fw)
 	fw->state = FW_INC;
 }
 
-void init_flow(struct flow *fw, int block_size, uint64_t total_size,
+void init_flow(struct flow *fw, int block_size, uint64_t total_blocks,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent)
 {
-	fw->total_size		= total_size;
+	fw->total_blocks	= total_blocks;
 	fw->cb			= cb;
 	fw->indent		= indent;
 	fw->block_size		= block_size; /* Bytes		*/
@@ -150,7 +150,8 @@ static inline bool has_enough_measurements(const struct flow *fw)
 
 static void report_progress(struct flow *fw, double inst_speed)
 {
-	const uint64_t total_processed = fw_get_total_processed(fw);
+	const uint64_t total_processed_blocks =
+		fw_get_total_processed_blocks(fw);
 	const char *unit = adjust_unit(&inst_speed);
 	double percent;
 	char buf[128 + TIME_STR_SIZE];
@@ -162,21 +163,21 @@ static void report_progress(struct flow *fw, double inst_speed)
 	 * the initial free space isn't exactly reported
 	 * by the kernel; this issue has been seen on Macs.
 	 */
-	if (fw->total_size < total_processed)
-		fw->total_size = total_processed;
+	if (fw->total_blocks < total_processed_blocks)
+		fw->total_blocks = total_processed_blocks;
 
-	percent = total_processed * 100.0 / fw->total_size;
+	percent = total_processed_blocks * 100.0 / fw->total_blocks;
 	c = snprintf(at_buf, rem_size, "%.2f%% -- %.2f %s/s",
 		percent, inst_speed, unit);
 	CHECK_AND_MOVE;
 
 	if (has_enough_measurements(fw)) {
-		const double rem_size_byte = fw->total_size - total_processed;
-		const double speed_byte_per_ns =
-			(double)(fw->measured_blocks * fw->block_size) /
-			fw->measured_time_ns;
+		const double rem_blocks =
+			fw->total_blocks - total_processed_blocks;
+		const double speed_blocks_per_ns =
+			(double)fw->measured_blocks / fw->measured_time_ns;
 		const uint64_t rem_time_ns =
-			round(rem_size_byte / speed_byte_per_ns);
+			round(rem_blocks / speed_blocks_per_ns);
 
 		c = snprintf(at_buf, rem_size, " -- ");
 		CHECK_AND_MOVE;

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -66,8 +66,7 @@ static inline void move_to_inc_at_start(struct flow *fw)
 }
 
 void init_flow(struct flow *fw, int block_size, uint64_t total_size,
-	uint64_t max_process_rate, progress_cb cb, unsigned int indent,
-	flow_func_flush_chunk_t func_flush_chunk)
+	uint64_t max_process_rate, progress_cb cb, unsigned int indent)
 {
 	fw->total_size		= total_size;
 	fw->total_processed	= 0;
@@ -81,7 +80,6 @@ void init_flow(struct flow *fw, int block_size, uint64_t total_size,
 	fw->measured_blocks	= 0;
 	fw->measured_time_ns	= 0;
 	fw->erase		= 0;
-	fw->func_flush_chunk	= func_flush_chunk;
 	fw->has_rem_chunk_size	= false;
 	fw->rem_chunk_size	= 0;
 	fw->rem_chunk_speed	= 0;
@@ -275,13 +273,6 @@ static inline int is_rate_below(const struct flow *fw,
 	return delay_ns <= fw->delay_ns && inst_speed < fw->max_process_rate;
 }
 
-static inline int flush_chunk(const struct flow *fw, int fd)
-{
-	if (fw->func_flush_chunk)
-		return fw->func_flush_chunk(fw, fd);
-	return 0;
-}
-
 static void update_rem_chunk_size(struct flow *fw, double inst_speed)
 {
 	if (fw->rem_chunk_size != 0 && inst_speed < fw->rem_chunk_speed)
@@ -291,7 +282,7 @@ static void update_rem_chunk_size(struct flow *fw, double inst_speed)
 	fw->rem_chunk_speed = inst_speed;
 }
 
-int measure(int fd, struct flow *fw, long processed)
+int measure(struct flow *fw, long processed)
 {
 	ldiv_t result = ldiv(processed, fw->block_size);
 	struct timespec t2;
@@ -305,9 +296,6 @@ int measure(int fd, struct flow *fw, long processed)
 	if (fw->processed_blocks < fw->blocks_per_delay)
 		return 0;
 	assert(fw->processed_blocks == fw->blocks_per_delay);
-
-	if (flush_chunk(fw, fd) < 0)
-		return -1; /* Caller can read errno(3). */
 
 	assert(!clock_gettime(CLOCK_MONOTONIC, &t2));
 	delay_ns = diff_timespec_ns(&fw->t1, &t2) + fw->acc_delay_ns;
@@ -462,34 +450,15 @@ int measure(int fd, struct flow *fw, long processed)
 	return 0;
 }
 
-int end_measurement(int fd, struct flow *fw)
+void end_measurement(struct flow *fw)
 {
-	struct timespec t2;
-	int saved_errno;
-	int ret = 0;
-
-	if (fw->processed_blocks <= 0)
-		goto out;
-
-	if (flush_chunk(fw, fd) < 0) {
-		saved_errno = errno;
-		ret = -1;
-		goto out;
+	if (fw->processed_blocks > 0) {
+		/* Track progress in between files. */
+		struct timespec t2;
+		assert(!clock_gettime(CLOCK_MONOTONIC, &t2));
+		fw->acc_delay_ns += diff_timespec_ns(&fw->t1, &t2);
 	}
-
-	/* Save time in between closing ongoing file and creating a new file. */
-	assert(!clock_gettime(CLOCK_MONOTONIC, &t2));
-	fw->acc_delay_ns += diff_timespec_ns(&fw->t1, &t2);
-
-out:
-	/* Erase progress information. */
-	clear_progress(fw);
-
-	if (ret < 0) {
-		/* Propagate errno(3) to caller. */
-		errno = saved_errno;
-	}
-	return ret;
+	clear_progress(fw); /* Erase progress information. */
 }
 
 void print_avg_seq_speed(const struct flow *fw, const char *speed_type,

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -198,13 +198,17 @@ static inline void __start_measurement(struct flow *fw)
 
 void start_measurement(struct flow *fw)
 {
+	uint64_t blocks, time_ns;
+
 	/*
 	 * The report below is especially useful when a single measurement spans
 	 * multiple files; this happens when a drive is faster than 1GB/s.
 	 */
-	report_progress(fw,
-		(fw->blocks_per_delay << fw->block_order) * 1000000000.0 /
-			fw->delay_ns);
+	fw_get_measurements(fw, &blocks, &time_ns);
+	if (time_ns > 0) {
+		report_progress(fw,
+			(blocks << fw->block_order) * 1000000000.0 / time_ns);
+	}
 	__start_measurement(fw);
 }
 

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -61,7 +61,7 @@ static void nssleep(uint64_t wait_ns)
 
 static inline void move_to_inc_at_start(struct flow *fw)
 {
-	fw->step = 1;
+	fw->step_blocks = 1;
 	fw->state = FW_INC;
 }
 
@@ -233,17 +233,19 @@ static void move_to_search(struct flow *fw, uint64_t bpd1, uint64_t bpd2)
 
 static inline void dec_step(struct flow *fw)
 {
-	if (fw->blocks_per_delay > fw->step) {
-		fw->blocks_per_delay -= fw->step;
-		fw->step *= 2;
-	} else
-		move_to_search(fw, 1, fw->blocks_per_delay + fw->step / 2);
+	if (fw->blocks_per_delay > fw->step_blocks) {
+		fw->blocks_per_delay -= fw->step_blocks;
+		fw->step_blocks *= 2;
+	} else {
+		move_to_search(fw, 1,
+			fw->blocks_per_delay + fw->step_blocks / 2);
+	}
 }
 
 static inline void inc_step(struct flow *fw)
 {
-	fw->blocks_per_delay += fw->step;
-	fw->step *= 2;
+	fw->blocks_per_delay += fw->step_blocks;
+	fw->step_blocks *= 2;
 }
 
 static inline void move_to_inc(struct flow *fw)
@@ -254,7 +256,7 @@ static inline void move_to_inc(struct flow *fw)
 
 static inline void move_to_dec(struct flow *fw)
 {
-	fw->step = 1;
+	fw->step_blocks = 1;
 	fw->state = FW_DEC;
 	dec_step(fw);
 }
@@ -380,7 +382,7 @@ int measure(struct flow *fw, long processed)
 				fw->has_rem_chunk_size = true;
 			}
 			move_to_search(fw,
-				fw->blocks_per_delay - fw->step / 2,
+				fw->blocks_per_delay - fw->step_blocks / 2,
 				fw->blocks_per_delay);
 		} else if (is_rate_below(fw, delay_ns, inst_speed)) {
 			inc_step(fw);
@@ -393,7 +395,7 @@ int measure(struct flow *fw, long processed)
 			dec_step(fw);
 		} else if (is_rate_below(fw, delay_ns, inst_speed)) {
 			move_to_search(fw, fw->blocks_per_delay,
-				fw->blocks_per_delay + fw->step / 2);
+				fw->blocks_per_delay + fw->step_blocks / 2);
 		} else
 			move_to_steady(fw);
 		break;

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -497,30 +497,58 @@ void dbuf_free(struct dynamic_buffer *dbuf)
 	dbuf->max_buf = true;
 }
 
-char *dbuf_get_buf(struct dynamic_buffer *dbuf, size_t size)
+char *dbuf_get_buf(struct dynamic_buffer *dbuf, int align_order,
+	size_t *psize)
 {
-	/* If enough buffer, or it's already the largest buffer, return it. */
-	if (size <= dbuf->len || dbuf->max_buf)
-		return dbuf->buf;
+	const int max_align_order = ilog2(alignof(max_align_t));
+	const size_t original_size = *psize;
+	size_t size = original_size;
+	size_t alignment, threshold;
+	int shift;
+	char *ret;
+
+	if (align_order < max_align_order)
+		align_order = max_align_order;
+	alignment = 1ULL << align_order;
+
+	/* If enough buffer and aligned, return it. */
+	if (size <= dbuf->len && is_aligned(dbuf->buf, alignment)) {
+		assert(*psize == original_size);
+		ret = dbuf->buf;
+		goto out;
+	}
+
+	if (dbuf->max_buf) {
+		/* It's already the largest buffer. */
+		goto align;
+	}
 
 	/*
 	 * Allocate a new buffer.
 	 */
-
 	__dbuf_free(dbuf);
+	threshold = sizeof(dbuf->backup_buf) - align_head(align_order);
 	do {
-		dbuf->buf = malloc(size);
+		dbuf->buf = aligned_alloc(alignment, size);
 		if (dbuf->buf != NULL) {
 			dbuf->len = size;
-			return dbuf->buf;
+			*psize = size;
+			ret = dbuf->buf;
+			goto out;
 		} else {
 			dbuf->max_buf = true;
 		}
 		size /= 2;
-	} while (size > sizeof(dbuf->backup_buf));
+	} while (size > threshold);
 
 	/* A larger buffer is not available; failsafe. */
 	dbuf->buf = dbuf->backup_buf;
 	dbuf->len = sizeof(dbuf->backup_buf);
-	return dbuf->buf;
+
+align:
+	ret = align_mem2(dbuf->buf, align_order, &shift);
+	*psize = MIN(*psize, dbuf->len - shift);
+out:
+	assert(*psize <= original_size);
+	return ret;
 }

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -92,9 +92,9 @@ void init_flow(struct flow *fw, int block_size, uint64_t total_size,
 
 uint64_t get_rem_chunk_size(const struct flow *fw)
 {
-	const int64_t rem_blocks = fw->blocks_per_delay - fw->processed_blocks;
+	const uint64_t rem_blocks = fw->blocks_per_delay - fw->processed_blocks;
 	const uint64_t rem_size = rem_blocks * fw->block_size;
-	assert(rem_blocks > 0);
+	assert(fw->blocks_per_delay > fw->processed_blocks);
 	return fw->has_rem_chunk_size && rem_size >= fw->rem_chunk_size
 		? fw->rem_chunk_size
 		: rem_size;
@@ -113,7 +113,7 @@ void clear_progress(struct flow *fw)
 {
 	char buf[512], *at_buf = buf;
 
-	if (fw->erase <= 0) {
+	if (fw->erase == 0) {
 		if (fw->indent > 0) {
 			/* Remove indented empty line. */
 			fw->cb(fw->indent, "\b");
@@ -121,7 +121,7 @@ void clear_progress(struct flow *fw)
 		goto out;
 	}
 
-	assert((size_t)fw->erase * 3 + 1 <= sizeof(buf));
+	assert(fw->erase * 3 + 1 <= sizeof(buf));
 	at_buf += repeat_ch(at_buf, '\b', fw->erase);
 	at_buf += repeat_ch(at_buf, ' ', fw->erase);
 	at_buf += repeat_ch(at_buf, '\b', fw->erase);
@@ -214,7 +214,7 @@ static inline void move_to_steady(struct flow *fw)
 	fw->state = FW_STEADY;
 }
 
-static void move_to_search(struct flow *fw, int64_t bpd1, int64_t bpd2)
+static void move_to_search(struct flow *fw, uint64_t bpd1, uint64_t bpd2)
 {
 	assert(bpd1 > 0);
 	assert(bpd2 >= bpd1);
@@ -232,7 +232,7 @@ static void move_to_search(struct flow *fw, int64_t bpd1, int64_t bpd2)
 
 static inline void dec_step(struct flow *fw)
 {
-	if (fw->blocks_per_delay - fw->step > 0) {
+	if (fw->blocks_per_delay > fw->step) {
 		fw->blocks_per_delay -= fw->step;
 		fw->step *= 2;
 	} else

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -68,36 +68,35 @@ static inline void move_to_inc_at_start(struct flow *fw)
 void init_flow(struct flow *fw, int block_size, uint64_t total_blocks,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent)
 {
-	fw->total_blocks	= total_blocks;
-	fw->cb			= cb;
-	fw->indent		= indent;
-	fw->block_size		= block_size; /* Bytes		*/
-	fw->blocks_per_delay	= 1;	/* block_size B/s	*/
-	fw->delay_ns		= 1000000000ULL;	/* 1s	*/
-	fw->max_process_rate	= max_process_rate == 0
+	fw->total_blocks		= total_blocks;
+	fw->cb				= cb;
+	fw->indent			= indent;
+	fw->block_size			= block_size; /* Bytes		*/
+	fw->blocks_per_delay		= 1;	/* block_size B/s	*/
+	fw->delay_ns			= 1000000000ULL;	/* 1s	*/
+	fw->max_process_rate		= max_process_rate == 0
 		? DBL_MAX : max_process_rate * 1024.;
-	fw->measured_blocks	= 0;
-	fw->measured_time_ns	= 0;
-	fw->erase		= 0;
-	fw->has_rem_chunk_size	= false;
-	fw->rem_chunk_size	= 0;
-	fw->rem_chunk_speed	= 0;
-	fw->processed_blocks	= 0;
-	fw->acc_delay_ns	= 0;
+	fw->measured_blocks		= 0;
+	fw->measured_time_ns		= 0;
+	fw->erase			= 0;
+	fw->has_rem_chunk_blocks	= false;
+	fw->rem_chunk_blocks		= 0;
+	fw->rem_chunk_speed		= 0;
+	fw->processed_blocks		= 0;
+	fw->acc_delay_ns		= 0;
 	assert(fw->block_size > 0);
 	assert(fw->block_size % SECTOR_SIZE == 0);
 
 	move_to_inc_at_start(fw);
 }
 
-uint64_t get_rem_chunk_size(const struct flow *fw)
+uint64_t get_rem_chunk_blocks(const struct flow *fw)
 {
 	const uint64_t rem_blocks = fw->blocks_per_delay - fw->processed_blocks;
-	const uint64_t rem_size = rem_blocks * fw->block_size;
 	assert(fw->blocks_per_delay > fw->processed_blocks);
-	return fw->has_rem_chunk_size && rem_size >= fw->rem_chunk_size
-		? fw->rem_chunk_size
-		: rem_size;
+	return fw->has_rem_chunk_blocks && rem_blocks >= fw->rem_chunk_blocks
+		? fw->rem_chunk_blocks
+		: rem_blocks;
 }
 
 static inline unsigned int repeat_ch(char *buf, char ch, int count)
@@ -275,27 +274,24 @@ static inline int is_rate_below(const struct flow *fw,
 	return delay_ns <= fw->delay_ns && inst_speed < fw->max_process_rate;
 }
 
-static void update_rem_chunk_size(struct flow *fw, double inst_speed)
+static void update_rem_chunk_blocks(struct flow *fw, double inst_speed)
 {
-	if (fw->rem_chunk_size != 0 && inst_speed < fw->rem_chunk_speed)
+	if (fw->rem_chunk_blocks != 0 && inst_speed < fw->rem_chunk_speed)
 		return;
 
-	fw->rem_chunk_size = (uint64_t)fw->blocks_per_delay * fw->block_size;
+	fw->rem_chunk_blocks = fw->blocks_per_delay;
 	fw->rem_chunk_speed = inst_speed;
 }
 
-int measure(struct flow *fw, long processed)
+void measure(struct flow *fw, uint64_t processed_blocks)
 {
-	ldiv_t result = ldiv(processed, fw->block_size);
 	struct timespec t2;
 	uint64_t delay_ns;
 	double bytes_g, inst_speed;
 
-	assert(result.rem == 0);
-	fw->processed_blocks += result.quot;
-
+	fw->processed_blocks += processed_blocks;
 	if (fw->processed_blocks < fw->blocks_per_delay)
-		return 0;
+		return;
 	assert(fw->processed_blocks == fw->blocks_per_delay);
 
 	assert(!clock_gettime(CLOCK_MONOTONIC, &t2));
@@ -304,8 +300,8 @@ int measure(struct flow *fw, long processed)
 	/* Instantaneous speed in bytes per second. */
 	inst_speed = bytes_g / delay_ns;
 
-	if (!fw->has_rem_chunk_size)
-		update_rem_chunk_size(fw, inst_speed);
+	if (!fw->has_rem_chunk_blocks)
+		update_rem_chunk_blocks(fw, inst_speed);
 
 	if (delay_ns < fw->delay_ns && inst_speed > fw->max_process_rate) {
 		/* delay_ns should be such that
@@ -376,10 +372,10 @@ int measure(struct flow *fw, long processed)
 	switch (fw->state) {
 	case FW_INC:
 		if (is_rate_above(fw, delay_ns, inst_speed)) {
-			if (!fw->has_rem_chunk_size) {
+			if (!fw->has_rem_chunk_blocks) {
 				/* Recommend a chunk size to caller. */
-				assert(fw->rem_chunk_size != 0);
-				fw->has_rem_chunk_size = true;
+				assert(fw->rem_chunk_blocks != 0);
+				fw->has_rem_chunk_blocks = true;
 			}
 			move_to_search(fw,
 				fw->blocks_per_delay - fw->step_blocks / 2,
@@ -417,13 +413,13 @@ int measure(struct flow *fw, long processed)
 		break;
 
 	case FW_STEADY: {
-		if (!fw->has_rem_chunk_size) {
+		if (!fw->has_rem_chunk_blocks) {
 			/* Recommend a chunk size to caller.
 			 * Execution reaches here when fw->max_process_rate is
 			 * throttling the flow.
 			 */
-			assert(fw->rem_chunk_size != 0);
-			fw->has_rem_chunk_size = true;
+			assert(fw->rem_chunk_blocks != 0);
+			fw->has_rem_chunk_blocks = true;
 			/* Since it's in steady state, go for another round
 			 * before making any change.
 			 */
@@ -447,7 +443,6 @@ int measure(struct flow *fw, long processed)
 
 	report_progress(fw, inst_speed);
 	__start_measurement(fw);
-	return 0;
 }
 
 void end_measurement(struct flow *fw)

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -69,7 +69,6 @@ void init_flow(struct flow *fw, int block_size, uint64_t total_size,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent)
 {
 	fw->total_size		= total_size;
-	fw->total_processed	= 0;
 	fw->cb			= cb;
 	fw->indent		= indent;
 	fw->block_size		= block_size; /* Bytes		*/
@@ -151,6 +150,7 @@ static inline bool has_enough_measurements(const struct flow *fw)
 
 static void report_progress(struct flow *fw, double inst_speed)
 {
+	const uint64_t total_processed = fw_get_total_processed(fw);
 	const char *unit = adjust_unit(&inst_speed);
 	double percent;
 	char buf[128 + TIME_STR_SIZE];
@@ -162,17 +162,16 @@ static void report_progress(struct flow *fw, double inst_speed)
 	 * the initial free space isn't exactly reported
 	 * by the kernel; this issue has been seen on Macs.
 	 */
-	if (fw->total_size < fw->total_processed)
-		fw->total_size = fw->total_processed;
+	if (fw->total_size < total_processed)
+		fw->total_size = total_processed;
 
-	percent = fw->total_processed * 100.0 / fw->total_size;
+	percent = total_processed * 100.0 / fw->total_size;
 	c = snprintf(at_buf, rem_size, "%.2f%% -- %.2f %s/s",
 		percent, inst_speed, unit);
 	CHECK_AND_MOVE;
 
 	if (has_enough_measurements(fw)) {
-		const double rem_size_byte =
-			fw->total_size - fw->total_processed;
+		const double rem_size_byte = fw->total_size - total_processed;
 		const double speed_byte_per_ns =
 			(double)(fw->measured_blocks * fw->block_size) /
 			fw->measured_time_ns;
@@ -291,7 +290,6 @@ int measure(struct flow *fw, long processed)
 
 	assert(result.rem == 0);
 	fw->processed_blocks += result.quot;
-	fw->total_processed += processed;
 
 	if (fw->processed_blocks < fw->blocks_per_delay)
 		return 0;
@@ -365,9 +363,12 @@ int measure(struct flow *fw, long processed)
 		}
 	}
 
-	/* Update mean. */
+	/* Update average. */
 	fw->measured_blocks += fw->processed_blocks;
 	fw->measured_time_ns += delay_ns;
+	/* Reset accumulators. */
+	fw->processed_blocks = 0;
+	fw->acc_delay_ns = 0;
 
 	switch (fw->state) {
 	case FW_INC:
@@ -442,10 +443,6 @@ int measure(struct flow *fw, long processed)
 	}
 
 	report_progress(fw, inst_speed);
-
-	/* Reset accumulators. */
-	fw->processed_blocks = 0;
-	fw->acc_delay_ns = 0;
 	__start_measurement(fw);
 	return 0;
 }

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -65,7 +65,7 @@ struct flow {
 /* If @max_process_rate == 0, the maximum processing rate is infinity.
  * The unit of @max_process_rate is KB per second.
  */
-void init_flow(struct flow *fw, int block_size, uint64_t total_blocks,
+void init_flow(struct flow *fw, unsigned int block_size, uint64_t total_blocks,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent);
 
 /* Total number of blocks already processed. */
@@ -74,12 +74,12 @@ static inline uint64_t fw_get_total_processed_blocks(const struct flow *fw)
 	return fw->measured_blocks + fw->processed_blocks;
 }
 
-static inline int fw_get_block_size(const struct flow *fw)
+static inline unsigned int fw_get_block_size(const struct flow *fw)
 {
 	return fw->block_size;
 }
 
-static inline int fw_get_block_order(const struct flow *fw)
+static inline unsigned int fw_get_block_order(const struct flow *fw)
 {
 	return ilog2(fw->block_size);
 }
@@ -135,7 +135,7 @@ void dbuf_free(struct dynamic_buffer *dbuf);
  * the input value of *psize in bytes, this function never returns NULL.
  * The input value of *psize is the maximum size of the returned buffer.
  */
-char *dbuf_get_buf(struct dynamic_buffer *dbuf, int align_order,
+char *dbuf_get_buf(struct dynamic_buffer *dbuf, unsigned int align_order,
 	size_t *psize);
 
 #endif	/* HEADER_LIBFLOW_H */

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -19,8 +19,8 @@ struct flow {
 	progress_cb	cb;
 	/* Indentation level for callback. */
 	unsigned int	indent;
-	/* Block size in bytes. */
-	unsigned int	block_size;
+	/* Block order. */
+	unsigned int	block_order;
 	/* Delay intended between measurements in nanoseconds. */
 	uint64_t	delay_ns;
 	/* Increment to apply to @blocks_per_delay. */
@@ -65,7 +65,7 @@ struct flow {
 /* If @max_process_rate == 0, the maximum processing rate is infinity.
  * The unit of @max_process_rate is KB per second.
  */
-void init_flow(struct flow *fw, unsigned int block_size, uint64_t total_blocks,
+void init_flow(struct flow *fw, unsigned int block_order, uint64_t total_blocks,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent);
 
 /* Total number of blocks already processed. */
@@ -76,12 +76,12 @@ static inline uint64_t fw_get_total_processed_blocks(const struct flow *fw)
 
 static inline unsigned int fw_get_block_size(const struct flow *fw)
 {
-	return fw->block_size;
+	return 1U << fw->block_order;
 }
 
 static inline unsigned int fw_get_block_order(const struct flow *fw)
 {
-	return ilog2(fw->block_size);
+	return fw->block_order;
 }
 
 static inline void inc_total_blocks(struct flow *fw, uint64_t n_blocks)

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -24,7 +24,7 @@ struct flow {
 	/* Delay intended between measurements in nanoseconds. */
 	uint64_t	delay_ns;
 	/* Increment to apply to @blocks_per_delay. */
-	uint64_t	step;
+	uint64_t	step_blocks;
 	/* Blocks to process before measurement. */
 	uint64_t	blocks_per_delay;
 	/* Maximum processing rate in bytes per second. */

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -127,14 +127,11 @@ static inline void dbuf_init(struct dynamic_buffer *dbuf)
 void dbuf_free(struct dynamic_buffer *dbuf);
 
 /*
- * Although the returned buffer may be smaller than @size,
- * this function never returns NULL.
+ * Although the returned buffer may be smaller than
+ * the input value of *psize in bytes, this function never returns NULL.
+ * The input value of *psize is the maximum size of the returned buffer.
  */
-char *dbuf_get_buf(struct dynamic_buffer *dbuf, size_t size);
-
-static inline size_t dbuf_get_len(const struct dynamic_buffer *dbuf)
-{
-	return dbuf->len;
-}
+char *dbuf_get_buf(struct dynamic_buffer *dbuf, int align_order,
+	size_t *psize);
 
 #endif	/* HEADER_LIBFLOW_H */

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -12,8 +12,6 @@
 
 struct flow;
 
-typedef int (*flow_func_flush_chunk_t)(const struct flow *fw, int fd);
-
 struct flow {
 	/* Total number of bytes to be processed. */
 	uint64_t	total_size;
@@ -43,11 +41,6 @@ struct flow {
 	int		erase;
 
 	/*
-	 * Methods
-	 */
-	flow_func_flush_chunk_t func_flush_chunk;
-
-	/*
 	 * Initialized while measuring
 	 */
 
@@ -75,8 +68,7 @@ struct flow {
  * The unit of @max_process_rate is KB per second.
  */
 void init_flow(struct flow *fw, int block_size, uint64_t total_size,
-	uint64_t max_process_rate, progress_cb cb, unsigned int indent,
-	flow_func_flush_chunk_t func_flush_chunk);
+	uint64_t max_process_rate, progress_cb cb, unsigned int indent);
 
 static inline int fw_get_block_size(const struct flow *fw)
 {
@@ -108,9 +100,9 @@ static inline void fw_get_measurements(const struct flow *fw,
 uint64_t get_rem_chunk_size(const struct flow *fw);
 
 void start_measurement(struct flow *fw);
-int measure(int fd, struct flow *fw, long processed);
+int measure(struct flow *fw, long processed);
 void clear_progress(struct flow *fw);
-int end_measurement(int fd, struct flow *fw);
+void end_measurement(struct flow *fw);
 
 void print_avg_seq_speed(const struct flow *fw, const char *speed_type,
 	bool use_sectors);

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -20,13 +20,13 @@ struct flow {
 	/* Indentation level for callback. */
 	unsigned int	indent;
 	/* Block size in bytes. */
-	int		block_size;
+	unsigned int	block_size;
 	/* Delay intended between measurements in nanoseconds. */
 	uint64_t	delay_ns;
 	/* Increment to apply to @blocks_per_delay. */
-	int64_t		step;
+	uint64_t	step;
 	/* Blocks to process before measurement. */
-	int64_t		blocks_per_delay;
+	uint64_t	blocks_per_delay;
 	/* Maximum processing rate in bytes per second. */
 	double		max_process_rate;
 	/* Number of measured blocks. */
@@ -36,7 +36,7 @@ struct flow {
 	/* State. */
 	enum {FW_INC, FW_DEC, FW_SEARCH, FW_STEADY} state;
 	/* Number of characters to erase before printing out progress. */
-	int		erase;
+	unsigned int	erase;
 
 	/*
 	 * Initialized while measuring
@@ -50,14 +50,14 @@ struct flow {
 	double		rem_chunk_speed;
 
 	/* Number of blocks processed since last measurement. */
-	int64_t		processed_blocks;
+	uint64_t	processed_blocks;
 	/*
 	 * Accumulated delay before @processed_blocks reaches @blocks_per_delay
 	 * in nanoseconds.
 	 */
 	uint64_t	acc_delay_ns;
 	/* Range of blocks_per_delay while in FW_SEARCH state. */
-	int64_t		bpd1, bpd2;
+	uint64_t	bpd1, bpd2;
 	/* Time measurements. */
 	struct timespec	t1;
 };
@@ -71,8 +71,7 @@ void init_flow(struct flow *fw, int block_size, uint64_t total_size,
 /* Total number of bytes already processed. */
 static inline uint64_t fw_get_total_processed(const struct flow *fw)
 {
-	return (uint64_t)(fw->measured_blocks + fw->processed_blocks) *
-		fw->block_size;
+	return (fw->measured_blocks + fw->processed_blocks) * fw->block_size;
 }
 
 static inline int fw_get_block_size(const struct flow *fw)

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -15,8 +15,6 @@ struct flow;
 struct flow {
 	/* Total number of bytes to be processed. */
 	uint64_t	total_size;
-	/* Total number of bytes already processed. */
-	uint64_t	total_processed;
 	/* Callback to show progress. */
 	progress_cb	cb;
 	/* Indentation level for callback. */
@@ -70,6 +68,13 @@ struct flow {
 void init_flow(struct flow *fw, int block_size, uint64_t total_size,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent);
 
+/* Total number of bytes already processed. */
+static inline uint64_t fw_get_total_processed(const struct flow *fw)
+{
+	return (uint64_t)(fw->measured_blocks + fw->processed_blocks) *
+		fw->block_size;
+}
+
 static inline int fw_get_block_size(const struct flow *fw)
 {
 	return fw->block_size;
@@ -82,7 +87,7 @@ static inline int fw_get_block_order(const struct flow *fw)
 
 static inline void inc_total_size(struct flow *fw, uint64_t size)
 {
-	fw->total_size = fw->total_processed + size;
+	fw->total_size = fw_get_total_processed(fw) + size;
 }
 
 static inline void fw_set_indent(struct flow *fw, unsigned int indent)

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -71,7 +71,7 @@ struct flow {
 	struct timespec	t1;
 };
 
-/* If @max_process_rate <= 0, the maximum processing rate is infinity.
+/* If @max_process_rate == 0, the maximum processing rate is infinity.
  * The unit of @max_process_rate is KB per second.
  */
 void init_flow(struct flow *fw, int block_size, uint64_t total_size,

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -43,9 +43,9 @@ struct flow {
 	 */
 
 	/* Has a recommended chunk size? */
-	bool		has_rem_chunk_size;
-	/* Recommended chunk size. */
-	uint64_t	rem_chunk_size;
+	bool		has_rem_chunk_blocks;
+	/* Recommended chunk size in blocks. */
+	uint64_t	rem_chunk_blocks;
 	/* Speed of the recommended chunk size in bytes per second. */
 	double		rem_chunk_speed;
 
@@ -101,10 +101,10 @@ static inline void fw_get_measurements(const struct flow *fw,
 	*time_ns = fw->measured_time_ns + fw->acc_delay_ns;
 }
 
-uint64_t get_rem_chunk_size(const struct flow *fw);
+uint64_t get_rem_chunk_blocks(const struct flow *fw);
 
 void start_measurement(struct flow *fw);
-int measure(struct flow *fw, long processed);
+void measure(struct flow *fw, uint64_t processed_blocks);
 void clear_progress(struct flow *fw);
 void end_measurement(struct flow *fw);
 

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -13,8 +13,8 @@
 struct flow;
 
 struct flow {
-	/* Total number of bytes to be processed. */
-	uint64_t	total_size;
+	/* Total number of blocks to be processed. */
+	uint64_t	total_blocks;
 	/* Callback to show progress. */
 	progress_cb	cb;
 	/* Indentation level for callback. */
@@ -65,13 +65,13 @@ struct flow {
 /* If @max_process_rate == 0, the maximum processing rate is infinity.
  * The unit of @max_process_rate is KB per second.
  */
-void init_flow(struct flow *fw, int block_size, uint64_t total_size,
+void init_flow(struct flow *fw, int block_size, uint64_t total_blocks,
 	uint64_t max_process_rate, progress_cb cb, unsigned int indent);
 
-/* Total number of bytes already processed. */
-static inline uint64_t fw_get_total_processed(const struct flow *fw)
+/* Total number of blocks already processed. */
+static inline uint64_t fw_get_total_processed_blocks(const struct flow *fw)
 {
-	return (fw->measured_blocks + fw->processed_blocks) * fw->block_size;
+	return fw->measured_blocks + fw->processed_blocks;
 }
 
 static inline int fw_get_block_size(const struct flow *fw)
@@ -84,9 +84,9 @@ static inline int fw_get_block_order(const struct flow *fw)
 	return ilog2(fw->block_size);
 }
 
-static inline void inc_total_size(struct flow *fw, uint64_t size)
+static inline void inc_total_blocks(struct flow *fw, uint64_t n_blocks)
 {
-	fw->total_size = fw_get_total_processed(fw) + size;
+	fw->total_blocks = fw_get_total_processed_blocks(fw) + n_blocks;
 }
 
 static inline void fw_set_indent(struct flow *fw, unsigned int indent)
@@ -97,7 +97,7 @@ static inline void fw_set_indent(struct flow *fw, unsigned int indent)
 static inline void fw_get_measurements(const struct flow *fw,
 	uint64_t *blocks, uint64_t *time_ns)
 {
-	*blocks = fw->measured_blocks + fw->processed_blocks;
+	*blocks = fw_get_total_processed_blocks(fw);
 	*time_ns = fw->measured_time_ns + fw->acc_delay_ns;
 }
 

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -55,8 +55,8 @@ static int write_random_blocks(struct device *dev, const uint64_t pos[],
 	uint32_t n_pos, struct rdwr_info *rwi, progress_cb cb,
 	unsigned int indent)
 {
-	const int block_order = dev_get_block_order(dev);
-	const int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
 	/* Aligning these pointers is necessary to directly read and write
 	 * the block device. For the file device, this is superfluous.
 	 */
@@ -87,8 +87,8 @@ static int write_blocks(struct device *dev,
 	uint64_t first_block, uint64_t last_block,
 	struct rdwr_info *rwi, progress_cb cb, unsigned int indent)
 {
-	const int block_order = dev_get_block_order(dev);
-	const int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
 	uint64_t offset = first_block << block_order;
 	uint64_t first_pos = first_block;
 
@@ -203,8 +203,8 @@ static int find_first_x_block(struct device *dev,
 	enum block_state *pstate, struct rdwr_info *rwi,
 	progress_cb cb, unsigned int indent)
 {
-	const int block_order = dev_get_block_order(dev);
-	const int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
 	char stack[align_head(block_order) + block_size];
 	char *probe_blk = align_mem(stack, block_order);
 	uint32_t i;
@@ -246,7 +246,7 @@ static int find_first_bad_block(struct device *dev, const uint64_t pos[],
 	uint32_t n_pos, bool *pany_bad, uint64_t *pbad_pos,
 	struct rdwr_info *rwi, progress_cb cb, unsigned int indent)
 {
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	struct def_x_block x_blocks[n_pos];
 	enum block_state bs;
 	uint32_t i;
@@ -531,7 +531,7 @@ static int find_cache_size(struct device *dev, const uint64_t left_pos,
 	uint64_t *pright_pos, struct rdwr_info *rwi, progress_cb cb,
 	unsigned int indent)
 {
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	const uint64_t end_pos = *pright_pos - 1;
 	uint64_t write_target = 1;
 	uint64_t final_write_target = MAX_CACHE_SIZE_BYTE >> block_order;
@@ -626,7 +626,7 @@ static int find_wrap(struct device *dev,
 	struct def_x_block x_blocks[n_samples];
 	bool any_bad;
 	uint64_t bad_pos;
-	int block_order;
+	unsigned int block_order;
 	uint64_t expected_offset, high_bit;
 	uint32_t i;
 	enum block_state bs;
@@ -695,7 +695,7 @@ static int find_wrap(struct device *dev,
 static uint64_t drive_mid_block(const struct device *dev)
 {
 	const uint64_t dev_size_byte = dev_get_size_byte(dev);
-	const int block_order = dev_get_block_order(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
 	return clp2((dev_size_byte >> block_order) / 2);
 }
 
@@ -774,7 +774,7 @@ uint64_t probe_max_written_blocks(const struct device *dev)
 }
 
 void report_probed_size(unsigned int indent, progress_cb cb,
-	const char *prefix, uint64_t bytes, int block_order)
+	const char *prefix, uint64_t bytes, unsigned int block_order)
 {
 	double f = bytes;
 	const char *unit = adjust_unit(&f);
@@ -784,7 +784,7 @@ void report_probed_size(unsigned int indent, progress_cb cb,
 }
 
 void report_probed_order(unsigned int indent, progress_cb cb,
-	const char *prefix, int order)
+	const char *prefix, unsigned int order)
 {
 	double f = (1ULL << order);
 	const char *unit = adjust_unit(&f);
@@ -793,7 +793,8 @@ void report_probed_order(unsigned int indent, progress_cb cb,
 }
 
 void report_probed_cache(unsigned int indent, progress_cb cb,
-	const char *prefix, uint64_t cache_size_block, int block_order)
+	const char *prefix, uint64_t cache_size_block,
+	unsigned int block_order)
 {
 	double f = (cache_size_block << block_order);
 	const char *unit = adjust_unit(&f);
@@ -807,8 +808,8 @@ int probe_device(struct device *dev, struct probe_results *results,
 	long max_read_rate, long max_write_rate)
 {
 	const uint64_t dev_size_byte = dev_get_size_byte(dev);
-	const int block_order = dev_get_block_order(dev);
-	const int block_size = dev_get_block_size(dev);
+	const unsigned int block_order = dev_get_block_order(dev);
+	const unsigned int block_size = dev_get_block_size(dev);
 	const progress_cb fw_cb = show_progress ? cb : dummy_cb;
 	uint64_t left_pos, right_pos, mid_drive_pos;
 	struct rdwr_info rwi;

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -77,9 +77,9 @@ static int write_random_blocks(struct device *dev, const uint64_t pos[],
 		if (_write_blocks(dev, buffer, pos[i], pos[i], &rwi->randw_fw,
 				cb, indent))
 			return true;
-		measure(0, &rwi->randw_fw, block_size);
+		measure(&rwi->randw_fw, block_size);
 	}
-	end_measurement(0, &rwi->randw_fw);
+	end_measurement(&rwi->randw_fw);
 	return false;
 }
 
@@ -136,13 +136,10 @@ static int write_blocks(struct device *dev,
 				&rwi->seqw_fw, cb, indent))
 			return true;
 
-		/* Since parameter func_flush_chunk of init_flow() is NULL,
-		 * the parameter fd of measure() is ignored.
-		 */
-		measure(0, &rwi->seqw_fw, blocks_to_write << block_order);
+		measure(&rwi->seqw_fw, blocks_to_write << block_order);
 		first_pos = next_pos + 1;
 	}
-	end_measurement(0, &rwi->seqw_fw);
+	end_measurement(&rwi->seqw_fw);
 	return false;
 }
 
@@ -239,17 +236,17 @@ static int find_first_x_block(struct device *dev,
 			return true;
 		bs = validate_buffer_with_block(probe_blk, block_order,
 			x_blocks[i].expected_offset, &found_offset, rwi->salt);
-		measure(0, &rwi->randr_fw, block_size);
+		measure(&rwi->randr_fw, block_size);
 
 		if (in_bs_set(bs_set, bs)) {
 			/* Found the first x_block. */
 			*pfirst_x_block_idx = i;
 			*pstate = bs;
-			end_measurement(0, &rwi->randr_fw);
+			end_measurement(&rwi->randr_fw);
 			return false;
 		}
 	}
-	end_measurement(0, &rwi->randr_fw);
+	end_measurement(&rwi->randr_fw);
 
 not_found:
 	*pfirst_x_block_idx = n_blocks;
@@ -834,9 +831,9 @@ int probe_device(struct device *dev, struct probe_results *results,
 	/* We initialize total_size to 0 because inc_total_size() is called
 	 * to update it when new blocks become available.
 	 */
-	init_flow(&rwi.seqw_fw, block_size, 0, max_write_rate, fw_cb, 0, NULL);
-	init_flow(&rwi.randw_fw, block_size, 0, max_write_rate, fw_cb, 0, NULL);
-	init_flow(&rwi.randr_fw, block_size, 0, max_read_rate, fw_cb, 0, NULL);
+	init_flow(&rwi.seqw_fw, block_size, 0, max_write_rate, fw_cb, 0);
+	init_flow(&rwi.randw_fw, block_size, 0, max_write_rate, fw_cb, 0);
+	init_flow(&rwi.randr_fw, block_size, 0, max_read_rate, fw_cb, 0);
 
 	/* @left_pos must point to a good block.
 	 * We just point to the last block of the first 1MB of the card

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -517,7 +517,7 @@ static int sampling_probe(struct device *dev,
 static void report_cache_size_test(unsigned int indent, progress_cb cb,
 	const struct device *dev, uint64_t first_pos, uint64_t last_pos)
 {
-	double f_size = (last_pos - first_pos + 1) * dev_get_block_size(dev);
+	double f_size = (last_pos - first_pos + 1) << dev_get_block_order(dev);
 	const char *unit = adjust_unit(&f_size);
 	cb(indent, "### Testing cache size: %.2f %s; Block%s [%" PRIu64 ", %" PRIu64 "]\n",
 		f_size, unit, first_pos != last_pos ? "s" : "",
@@ -809,7 +809,6 @@ int probe_device(struct device *dev, struct probe_results *results,
 {
 	const uint64_t dev_size_byte = dev_get_size_byte(dev);
 	const unsigned int block_order = dev_get_block_order(dev);
-	const unsigned int block_size = dev_get_block_size(dev);
 	const progress_cb fw_cb = show_progress ? cb : dummy_cb;
 	uint64_t left_pos, right_pos, mid_drive_pos;
 	struct rdwr_info rwi;
@@ -819,9 +818,9 @@ int probe_device(struct device *dev, struct probe_results *results,
 	/* We initialize total_blocks to 0 because inc_total_blocks() is called
 	 * to update it when new blocks become available.
 	 */
-	init_flow(&rwi.seqw_fw, block_size, 0, max_write_rate, fw_cb, 0);
-	init_flow(&rwi.randw_fw, block_size, 0, max_write_rate, fw_cb, 0);
-	init_flow(&rwi.randr_fw, block_size, 0, max_read_rate, fw_cb, 0);
+	init_flow(&rwi.seqw_fw, block_order, 0, max_write_rate, fw_cb, 0);
+	init_flow(&rwi.randw_fw, block_order, 0, max_write_rate, fw_cb, 0);
+	init_flow(&rwi.randr_fw, block_order, 0, max_read_rate, fw_cb, 0);
 
 	/* @left_pos must point to a good block.
 	 * We just point to the last block of the first 1MB of the card

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -67,7 +67,7 @@ static int write_random_blocks(struct device *dev, const uint64_t pos[],
 	if (n_pos == 0)
 		return false;
 
-	inc_total_size(&rwi->randw_fw, n_pos << block_order);
+	inc_total_blocks(&rwi->randw_fw, n_pos);
 	fw_set_indent(&rwi->randw_fw, indent);
 
 	start_measurement(&rwi->randw_fw);
@@ -95,8 +95,7 @@ static int write_blocks(struct device *dev,
 	if (first_block > last_block)
 		return false;
 
-	inc_total_size(&rwi->seqw_fw,
-		(last_block - first_block + 1) << block_order);
+	inc_total_blocks(&rwi->seqw_fw, last_block - first_block + 1);
 	fw_set_indent(&rwi->seqw_fw, indent);
 
 	start_measurement(&rwi->seqw_fw);
@@ -213,7 +212,7 @@ static int find_first_x_block(struct device *dev,
 	if (n_blocks == 0)
 		goto not_found;
 
-	inc_total_size(&rwi->randr_fw, n_blocks << block_order);
+	inc_total_blocks(&rwi->randr_fw, n_blocks);
 	fw_set_indent(&rwi->randr_fw, indent);
 
 	start_measurement(&rwi->randr_fw);
@@ -818,7 +817,7 @@ int probe_device(struct device *dev, struct probe_results *results,
 	assert(block_order <= 20);
 
 	dbuf_init(&rwi.seqw_dbuf);
-	/* We initialize total_size to 0 because inc_total_size() is called
+	/* We initialize total_blocks to 0 because inc_total_blocks() is called
 	 * to update it when new blocks become available.
 	 */
 	init_flow(&rwi.seqw_fw, block_size, 0, max_write_rate, fw_cb, 0);

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -102,42 +102,32 @@ static int write_blocks(struct device *dev,
 	start_measurement(&rwi->seqw_fw);
 	while (first_pos <= last_block) {
 		const uint64_t chunk_bytes = get_rem_chunk_size(&rwi->seqw_fw);
-		const uint64_t needed_size =
-			align_head(block_order) + chunk_bytes;
 		const uint64_t max_blocks_to_write =
 			last_block - first_pos + 1;
+		size_t buf_len = chunk_bytes;
 		uint64_t blocks_to_write;
-		int shift;
 		char *buffer, *stamp_blk;
-		size_t buf_len;
 		uint64_t pos, next_pos;
 
-		buffer = align_mem2(dbuf_get_buf(&rwi->seqw_dbuf, needed_size),
-			block_order, &shift);
-		buf_len = dbuf_get_len(&rwi->seqw_dbuf);
-
-		blocks_to_write = buf_len >= needed_size
-			? chunk_bytes >> block_order
-			: (buf_len - shift) >> block_order;
-		if (blocks_to_write > max_blocks_to_write)
-			blocks_to_write = max_blocks_to_write;
-
-		next_pos = first_pos + blocks_to_write - 1;
+		buffer = dbuf_get_buf(&rwi->seqw_dbuf, block_order, &buf_len);
+		blocks_to_write =
+			MIN(buf_len >> block_order, max_blocks_to_write);
+		next_pos = first_pos + blocks_to_write;
 
 		stamp_blk = buffer;
-		for (pos = first_pos; pos <= next_pos; pos++) {
+		for (pos = first_pos; pos < next_pos; pos++) {
 			fill_buffer_with_block(stamp_blk, block_order, offset,
 				rwi->salt);
 			stamp_blk += block_size;
 			offset += block_size;
 		}
 
-		if (_write_blocks(dev, buffer, first_pos, next_pos,
+		if (_write_blocks(dev, buffer, first_pos, next_pos - 1,
 				&rwi->seqw_fw, cb, indent))
 			return true;
 
 		measure(&rwi->seqw_fw, blocks_to_write << block_order);
-		first_pos = next_pos + 1;
+		first_pos = next_pos;
 	}
 	end_measurement(&rwi->seqw_fw);
 	return false;

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -814,8 +814,6 @@ int probe_device(struct device *dev, struct probe_results *results,
 	struct rdwr_info rwi;
 	int wrap;
 
-	assert(block_order <= 20);
-
 	dbuf_init(&rwi.seqw_dbuf);
 	/* We initialize total_blocks to 0 because inc_total_blocks() is called
 	 * to update it when new blocks become available.
@@ -831,7 +829,8 @@ int probe_device(struct device *dev, struct probe_results *results,
 	 * Given that all writing is confined to the interval
 	 * (@left_pos, @right_pos), we avoid losing the partition table.
 	 */
-	left_pos = (1ULL << (20 - block_order)) - 1;
+	assert(block_order <= MEGABYTE_ORDER);
+	left_pos = (1ULL << (MEGABYTE_ORDER - block_order)) - 1;
 
 	/* @right_pos must point to a bad block.
 	 * We just point to the block after the very last block.

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -77,7 +77,7 @@ static int write_random_blocks(struct device *dev, const uint64_t pos[],
 		if (_write_blocks(dev, buffer, pos[i], pos[i], &rwi->randw_fw,
 				cb, indent))
 			return true;
-		measure(&rwi->randw_fw, block_size);
+		measure(&rwi->randw_fw, 1);
 	}
 	end_measurement(&rwi->randw_fw);
 	return false;
@@ -100,17 +100,17 @@ static int write_blocks(struct device *dev,
 
 	start_measurement(&rwi->seqw_fw);
 	while (first_pos <= last_block) {
-		const uint64_t chunk_bytes = get_rem_chunk_size(&rwi->seqw_fw);
-		const uint64_t max_blocks_to_write =
-			last_block - first_pos + 1;
-		size_t buf_len = chunk_bytes;
-		uint64_t blocks_to_write;
+		const uint64_t max_blocks_to_write = last_block - first_pos + 1;
+		uint64_t blocks_to_write = MIN(
+			get_rem_chunk_blocks(&rwi->seqw_fw),
+			max_blocks_to_write);
+		size_t buf_len = blocks_to_write << block_order;
 		char *buffer, *stamp_blk;
 		uint64_t pos, next_pos;
 
 		buffer = dbuf_get_buf(&rwi->seqw_dbuf, block_order, &buf_len);
-		blocks_to_write =
-			MIN(buf_len >> block_order, max_blocks_to_write);
+		blocks_to_write = buf_len >> block_order;
+		assert(blocks_to_write > 0);
 		next_pos = first_pos + blocks_to_write;
 
 		stamp_blk = buffer;
@@ -125,7 +125,7 @@ static int write_blocks(struct device *dev,
 				&rwi->seqw_fw, cb, indent))
 			return true;
 
-		measure(&rwi->seqw_fw, blocks_to_write << block_order);
+		measure(&rwi->seqw_fw, blocks_to_write);
 		first_pos = next_pos;
 	}
 	end_measurement(&rwi->seqw_fw);
@@ -225,7 +225,7 @@ static int find_first_x_block(struct device *dev,
 			return true;
 		bs = validate_buffer_with_block(probe_blk, block_order,
 			x_blocks[i].expected_offset, &found_offset, rwi->salt);
-		measure(&rwi->randr_fw, block_size);
+		measure(&rwi->randr_fw, 1);
 
 		if (in_bs_set(bs_set, bs)) {
 			/* Found the first x_block. */

--- a/src/libprobe.h
+++ b/src/libprobe.h
@@ -17,20 +17,21 @@
 uint64_t probe_max_written_blocks(const struct device *dev);
 
 void report_probed_size(unsigned int indent, progress_cb cb,
-	const char *prefix, uint64_t bytes, int block_order);
+	const char *prefix, uint64_t bytes, unsigned int block_order);
 
 void report_probed_order(unsigned int indent, progress_cb cb,
-	const char *prefix, int order);
+	const char *prefix, unsigned int order);
 
 void report_probed_cache(unsigned int indent, progress_cb cb,
-	const char *prefix, uint64_t cache_size_block, int block_order);
+	const char *prefix, uint64_t cache_size_block,
+	unsigned int block_order);
 
 struct probe_results {
 	uint64_t real_size_byte;
 	uint64_t announced_size_byte;
 	int wrap;
 	uint64_t cache_size_block;
-	int block_order;
+	unsigned int block_order;
 
 	uint64_t seqw_blocks, seqw_time_ns;
 	uint64_t randw_blocks, randw_time_ns;

--- a/src/libutils.c
+++ b/src/libutils.c
@@ -323,24 +323,24 @@ enum block_state validate_block_update_stats(const void *buf,
 }
 
 static void print_stat(const char *prefix, uint64_t count,
-	unsigned int block_size, const char *unit_name)
+	unsigned int block_order, const char *unit_name)
 {
-	double f = (double)count * block_size;
+	double f = count << block_order;
 	const char *unit = adjust_unit(&f);
 	printf("%s %.2f %s (%" PRIu64 " %s%s)\n",
 		prefix, f, unit, count, unit_name, count != 1 ? "s" : "");
 }
 
-void print_stats(const struct block_stats *stats, unsigned int block_size,
+void print_stats(const struct block_stats *stats, unsigned int block_order,
 	const char *unit_name)
 {
-	print_stat("\n  Data OK:", stats->ok, block_size, unit_name);
+	print_stat("\n  Data OK:", stats->ok, block_order, unit_name);
 	print_stat("Data LOST:",
 		stats->bad + stats->changed + stats->overwritten,
-		block_size, unit_name);
-	print_stat("\t       Corrupted:", stats->bad, block_size, unit_name);
-	print_stat("\tSlightly changed:", stats->changed, block_size, unit_name);
-	print_stat("\t     Overwritten:", stats->overwritten, block_size, unit_name);
+		block_order, unit_name);
+	print_stat("\t       Corrupted:", stats->bad, block_order, unit_name);
+	print_stat("\tSlightly changed:", stats->changed, block_order, unit_name);
+	print_stat("\t     Overwritten:", stats->overwritten, block_order, unit_name);
 }
 
 void report_io_speed(unsigned int indent, progress_cb cb, const char *prefix,

--- a/src/libutils.c
+++ b/src/libutils.c
@@ -152,7 +152,7 @@ int nsec_to_str(uint64_t nsec, char *str)
 	return tot;
 }
 
-void *align_mem2(void *p, int order, int *shift)
+void *align_mem2(void *p, unsigned int order, int *shift)
 {
 	uintptr_t ip0 = (uintptr_t)p;
 	uintptr_t head = align_head(order);
@@ -221,10 +221,10 @@ static inline uint64_t next_random_number(uint64_t random_number)
 	return random_number * 4294967311ULL + 17;
 }
 
-void fill_buffer_with_block(void *buf, int block_order, uint64_t offset,
-	uint64_t salt)
+void fill_buffer_with_block(void *buf, unsigned int block_order,
+	uint64_t offset, uint64_t salt)
 {
-	const unsigned int num_int64 = 1 << (block_order - 3);
+	const unsigned int num_int64 = 1U << (block_order - 3);
 	uint64_t *int64_array = buf;
 	uint64_t random_number = offset ^ salt;
 	unsigned int i;
@@ -255,16 +255,17 @@ const char *block_state_to_str(enum block_state state)
 	return conv_array[state];
 }
 
-enum block_state validate_buffer_with_block(const void *buf, int block_order,
-	uint64_t expected_offset, uint64_t *pfound_offset, uint64_t salt)
+enum block_state validate_buffer_with_block(const void *buf,
+	unsigned int block_order, uint64_t expected_offset,
+	uint64_t *pfound_offset, uint64_t salt)
 {
 	const uint64_t *int64_array = buf;
 	const uint64_t found_offset = int64_array[0];
-	const int num_int64 = 1 << (block_order - 3);
+	const unsigned int num_int64 = 1U << (block_order - 3);
 	uint64_t random_number = found_offset ^ salt;
 	const unsigned int bit_error_tolerance = 7;
 	unsigned int bit_error_count = 0;
-	int i;
+	unsigned int i;
 
 	assert(block_order >= SECTOR_ORDER);
 
@@ -294,9 +295,9 @@ enum block_state validate_buffer_with_block(const void *buf, int block_order,
 	return bs_bad;
 }
 
-enum block_state validate_block_update_stats(const void *buf, int block_order,
-	uint64_t expected_offset, uint64_t *pfound_offset, uint64_t salt,
-	struct block_stats *stats)
+enum block_state validate_block_update_stats(const void *buf,
+	unsigned int block_order, uint64_t expected_offset,
+	uint64_t *pfound_offset, uint64_t salt, struct block_stats *stats)
 {
 	enum block_state state = validate_buffer_with_block(buf, block_order,
 		expected_offset, pfound_offset, salt);
@@ -322,7 +323,7 @@ enum block_state validate_block_update_stats(const void *buf, int block_order,
 }
 
 static void print_stat(const char *prefix, uint64_t count,
-	int block_size, const char *unit_name)
+	unsigned int block_size, const char *unit_name)
 {
 	double f = (double)count * block_size;
 	const char *unit = adjust_unit(&f);
@@ -330,7 +331,7 @@ static void print_stat(const char *prefix, uint64_t count,
 		prefix, f, unit, count, unit_name, count != 1 ? "s" : "");
 }
 
-void print_stats(const struct block_stats *stats, int block_size,
+void print_stats(const struct block_stats *stats, unsigned int block_size,
 	const char *unit_name)
 {
 	print_stat("\n  Data OK:", stats->ok, block_size, unit_name);
@@ -344,7 +345,7 @@ void print_stats(const struct block_stats *stats, int block_size,
 
 void report_io_speed(unsigned int indent, progress_cb cb, const char *prefix,
 	uint64_t blocks, const char *block_unit, uint64_t time_ns,
-	int block_order)
+	unsigned int block_order)
 {
 	double speed;
 	const char *unit;

--- a/src/libutils.h
+++ b/src/libutils.h
@@ -37,6 +37,11 @@ void printf_cb(unsigned int indent, const char *format, ...);
 void printf_flush_cb(unsigned int indent, const char *format, ...);
 void dummy_cb(unsigned int indent, const char *format, ...);
 
+static inline bool is_power_of_2(uint64_t x)
+{
+	return x && !(x & (x - 1));
+}
+
 int ilog2(uint64_t x);
 
 /* Least power of 2 greater than or equal to x. */
@@ -66,14 +71,14 @@ int nsec_to_str(uint64_t nsec, char *str);
  *	probe_blk = stamp_blk + block_size;
  */
 
-static inline int align_head(int order)
+static inline unsigned int align_head(unsigned int order)
 {
-	return (1 << order) - 1;
+	return (1U << order) - 1;
 }
 
-void *align_mem2(void *p, int order, int *shift);
+void *align_mem2(void *p, unsigned int order, int *shift);
 
-static inline void *align_mem(void *p, int order)
+static inline void *align_mem(void *p, unsigned int order)
 {
 	int shift;
 	return align_mem2(p, order, &shift);
@@ -92,8 +97,8 @@ void print_header(FILE *f, const char *name);
 long long arg_to_ll_bytes(const struct argp_state *state, const char *arg);
 
 /* Dependent on the byte order of the processor (i.e. endianness). */
-void fill_buffer_with_block(void *buf, int block_order, uint64_t offset,
-	uint64_t salt);
+void fill_buffer_with_block(void *buf, unsigned int block_order,
+	uint64_t offset, uint64_t salt);
 
 enum block_state {
 	bs_unknown,
@@ -113,12 +118,13 @@ struct block_stats {
 };
 
 /* Dependent on the byte order of the processor (i.e. endianness). */
-enum block_state validate_buffer_with_block(const void *buf, int block_order,
-	uint64_t expected_offset, uint64_t *pfound_offset, uint64_t salt);
+enum block_state validate_buffer_with_block(const void *buf,
+	unsigned int block_order, uint64_t expected_offset,
+	uint64_t *pfound_offset, uint64_t salt);
 
-enum block_state validate_block_update_stats(const void *buf, int block_order,
-	uint64_t expected_offset, uint64_t *pfound_offset, uint64_t salt,
-	struct block_stats *stats);
+enum block_state validate_block_update_stats(const void *buf,
+	unsigned int block_order, uint64_t expected_offset,
+	uint64_t *pfound_offset, uint64_t salt, struct block_stats *stats);
 
 static inline uint64_t diff_timespec_ns(const struct timespec *t1,
 	const struct timespec *t2)
@@ -127,11 +133,11 @@ static inline uint64_t diff_timespec_ns(const struct timespec *t1,
 		t2->tv_nsec - t1->tv_nsec;
 }
 
-void print_stats(const struct block_stats *stats, int block_size,
+void print_stats(const struct block_stats *stats, unsigned int block_size,
 	const char *unit_name);
 
 void report_io_speed(unsigned int indent, progress_cb cb, const char *prefix,
 	uint64_t blocks, const char *block_unit, uint64_t time_ns,
-	int block_order);
+	unsigned int block_order);
 
 #endif	/* HEADER_LIBUTILS_H */

--- a/src/libutils.h
+++ b/src/libutils.h
@@ -79,6 +79,14 @@ static inline void *align_mem(void *p, int order)
 	return align_mem2(p, order, &shift);
 }
 
+/* Return true if @ptr is aligned to @alignment.
+ * @alignment must be a power of 2.
+ */
+static inline bool is_aligned(const void *ptr, size_t alignment)
+{
+	return ((uintptr_t)ptr & (alignment - 1)) == 0;
+}
+
 void print_header(FILE *f, const char *name);
 
 long long arg_to_ll_bytes(const struct argp_state *state, const char *arg);

--- a/src/libutils.h
+++ b/src/libutils.h
@@ -17,14 +17,18 @@
 #define UNUSED(x)	((void)x)
 #define DIM(x)		(sizeof(x) / sizeof((x)[0]))
 
-static inline uint64_t uint64_min(uint64_t a, uint64_t b)
-{
-	return a < b ? a : b;
-}
+#define GEN_MIN(name, type)				\
+	static inline type name##_min(type a, type b)	\
+	{						\
+		return a < b ? a : b;			\
+	}
 
-#define MIN(a, b) _Generic((a),		\
-	uint64_t: uint64_min,		\
-	unsigned long long: uint64_min	\
+GEN_MIN(ul, unsigned long)
+GEN_MIN(ull, unsigned long long)
+
+#define MIN(a, b) _Generic(1 ? (a) : (b),	\
+	unsigned long: ul_min,			\
+	unsigned long long: ull_min		\
 	)(a, b)
 
 typedef void (*progress_cb)(unsigned int indent, const char *format, ...);

--- a/src/libutils.h
+++ b/src/libutils.h
@@ -133,7 +133,7 @@ static inline uint64_t diff_timespec_ns(const struct timespec *t1,
 		t2->tv_nsec - t1->tv_nsec;
 }
 
-void print_stats(const struct block_stats *stats, unsigned int block_size,
+void print_stats(const struct block_stats *stats, unsigned int block_order,
 	const char *unit_name);
 
 void report_io_speed(unsigned int indent, progress_cb cb, const char *prefix,


### PR DESCRIPTION
Since spinning off `f3write` in 2020, `libflow` has become a key aspect of how F3 works and is currently employed in `f3write`, `f3read`, `f3brew`, and `f3probe`. This pull request streamlines the interface of `libflow` by
1. Unifying size units with blocks. Each file system and block device has a block unit. Adopting the block unit of the underlying storage minimizes size conversions between units: bytes, sectors, and blocks; and
2. Operating with block order instead of block size. A block size is a power of 2, so operating with its exponent (i.e., $\log_2(\text{block size})$) simplifies arithmetic by replacing multiplications, divisions, and modulos with bit operations: left shift (`<<`), right shift (`>>`), and AND (`&`).

In addition, this interface review brings the following minor improvements:
1. Improved type safety by converting non-negative quantities (e.g., block counts, orders, and sizes) from signed to unsigned integers.
2. Renamed fields and functions to clarify that they operate on blocks rather than bytes (e.g., `total_size` → `total_blocks`, `step` → `step_blocks`, and `get_rem_chunk_size()` → `get_rem_chunk_blocks()`).
3. Dropped outdated `func_flush_chunk` parameter from `init_flow()` and the redundant `total_processed` field from `struct flow`.
4. Improved accuracy of the reported initial speed in `start_measurement()`.
5. Made `dbuf_get_buf()` alignment-aware, so several callers dropped their ad hoc solutions for memory alignment.