### PR TITLE
Add per-file I/O speed reporting

### DIFF
--- a/src/f3brew.c
+++ b/src/f3brew.c
@@ -296,7 +296,7 @@ static void write_blocks(struct device *dev, struct flow *fw,
 		measure(fw, blocks_to_write, NULL);
 		first_pos = next_pos;
 	}
-	end_measurement(fw);
+	end_measurement(fw, false);
 	dbuf_free(&dbuf);
 }
 
@@ -452,7 +452,7 @@ static void read_blocks(struct device *dev, struct flow *fw,
 		measure(fw, blocks_to_read, NULL);
 		first_pos = next_pos;
 	}
-	end_measurement(fw);
+	end_measurement(fw, false);
 	dbuf_free(&dbuf);
 
 	if (range.state != bs_unknown)

--- a/src/f3brew.c
+++ b/src/f3brew.c
@@ -293,7 +293,7 @@ static void write_blocks(struct device *dev, struct flow *fw,
 				" to 0x%" PRIx64, first_pos, next_pos - 1);
 		}
 
-		measure(fw, blocks_to_write);
+		measure(fw, blocks_to_write, NULL);
 		first_pos = next_pos;
 	}
 	end_measurement(fw);
@@ -449,7 +449,7 @@ static void read_blocks(struct device *dev, struct flow *fw,
 			probe_blk += block_size;
 		}
 
-		measure(fw, blocks_to_read);
+		measure(fw, blocks_to_read, NULL);
 		first_pos = next_pos;
 	}
 	end_measurement(fw);

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -7,6 +7,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <limits.h>
+#include <math.h>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -213,6 +214,11 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 {
 	const unsigned int block_size = fw_get_block_size(fw);
 	const unsigned int block_order = fw_get_block_order(fw);
+	double file_min_speed = INFINITY;
+	double file_max_speed = -INFINITY;
+	uint64_t file_tot_blocks = 0;
+	uint64_t file_tot_time_ns = 0;
+	uint64_t file_speed_samples = 0;
 	char *full_fn;
 	const char *filename;
 	int fd, saved_errno;
@@ -260,6 +266,7 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 	start_measurement(fw);
 	while (true) {
 		size_t bytes_read;
+		struct fw_measurement m;
 		int rc = check_chunk(fw, dbuf, fd, &expected_offset, stats,
 			&bytes_read);
 		if (rc == 0 && bytes_read == 0) {
@@ -267,7 +274,18 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 			break;
 		}
 		assert((bytes_read & (block_size - 1)) == 0);
-		measure(fw, bytes_read >> block_order, NULL);
+		measure(fw, bytes_read >> block_order, &m);
+		if (m.valid) {
+			double inst_speed = fw_get_speed(fw, m.blocks,
+				m.time_ns);
+			file_speed_samples++;
+			if (inst_speed > file_max_speed)
+				file_max_speed = inst_speed;
+			if (inst_speed < file_min_speed)
+				file_min_speed = inst_speed;
+			file_tot_blocks += m.blocks;
+			file_tot_time_ns += m.time_ns;
+		}
 		if (rc != 0) {
 			saved_errno = rc;
 			break;
@@ -285,8 +303,15 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 		printf(" - %s", strerror(saved_errno));
 	} else if (stats->bytes_read > 0) {
 		uint64_t file_time_ns = diff_timespec_ns(&file_t1, &file_t2);
+		double file_avg_speed;
 
-		if (file_time_ns > 0) {
+		if (file_speed_samples >= 2) {
+			file_avg_speed = fw_get_speed(fw, file_tot_blocks,
+				file_tot_time_ns);
+			print_avg_min_max_samples(" ", "",
+				file_avg_speed, file_min_speed,	file_max_speed,
+				file_speed_samples);
+		} else if (file_time_ns > 0) {
 			double file_avg_speed = fw_get_speed(fw,
 				(stats->bytes_read >> block_order),
 				file_time_ns);

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -291,7 +291,7 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 			break;
 		}
 	}
-	end_measurement(fw);
+	end_measurement(fw, true);
 	assert(!clock_gettime(CLOCK_MONOTONIC, &file_t2));
 
 	print_status(stats);

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -217,6 +217,7 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 	const char *filename;
 	int fd, saved_errno;
 	uint64_t expected_offset;
+	struct timespec file_t1, file_t2;
 
 	zero_fstats(stats);
 
@@ -255,6 +256,7 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 
 	saved_errno = 0;
 	expected_offset = number << GIGABYTE_ORDER;
+	assert(!clock_gettime(CLOCK_MONOTONIC, &file_t1));
 	start_measurement(fw);
 	while (true) {
 		size_t bytes_read;
@@ -272,6 +274,7 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 		}
 	}
 	end_measurement(fw);
+	assert(!clock_gettime(CLOCK_MONOTONIC, &file_t2));
 
 	print_status(stats);
 	if (!stats->read_all) {
@@ -280,6 +283,17 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 			strerror(saved_errno));
 	} else if (saved_errno != 0) {
 		printf(" - %s", strerror(saved_errno));
+	} else if (stats->bytes_read > 0) {
+		uint64_t file_time_ns = diff_timespec_ns(&file_t1, &file_t2);
+
+		if (file_time_ns > 0) {
+			double file_avg_speed = fw_get_speed(fw,
+				(stats->bytes_read >> block_order),
+				file_time_ns);
+			const char *unit = adjust_unit(&file_avg_speed);
+			assert((stats->bytes_read & (block_size - 1)) == 0);
+			printf(" Avg: %.2f %s/s", file_avg_speed, unit);
+		}
 	}
 	printf("\n");
 

--- a/src/f3read.c
+++ b/src/f3read.c
@@ -267,7 +267,7 @@ static void validate_file(struct flow *fw, struct dynamic_buffer *dbuf,
 			break;
 		}
 		assert((bytes_read & (block_size - 1)) == 0);
-		measure(fw, bytes_read >> block_order);
+		measure(fw, bytes_read >> block_order, NULL);
 		if (rc != 0) {
 			saved_errno = rc;
 			break;

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 #include <limits.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -184,6 +185,11 @@ static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 	const uint64_t total_file_blocks =
 		1ULL << (GIGABYTE_ORDER - block_order);
 	uint64_t remaining_blocks = total_file_blocks;
+	double file_min_speed = INFINITY;
+	double file_max_speed = -INFINITY;
+	uint64_t file_tot_blocks = 0;
+	uint64_t file_tot_time_ns = 0;
+	uint64_t file_speed_samples = 0;
 	char *full_fn;
 	const char *filename;
 	int fd, saved_errno;
@@ -216,6 +222,7 @@ static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 	while (remaining_blocks > 0) {
 		size_t bytes_written;
 		uint64_t written_blocks;
+		struct fw_measurement m;
 
 		saved_errno = write_chunk(fw, dbuf, fd, remaining_blocks,
 			&offset, &bytes_written);
@@ -235,7 +242,18 @@ static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 
 		assert((bytes_written & (block_size - 1)) == 0);
 		written_blocks = bytes_written >> block_order;
-		measure(fw, written_blocks);
+		measure(fw, written_blocks, &m);
+		if (m.valid) {
+			double inst_speed = fw_get_speed(fw, m.blocks,
+				m.time_ns);
+			file_speed_samples++;
+			if (inst_speed > file_max_speed)
+				file_max_speed = inst_speed;
+			if (inst_speed < file_min_speed)
+				file_min_speed = inst_speed;
+			file_tot_blocks += m.blocks;
+			file_tot_time_ns += m.time_ns;
+		}
 		remaining_blocks -= written_blocks;
 
 		if (saved_errno != 0)
@@ -248,12 +266,19 @@ static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 
 	if (saved_errno == 0 || saved_errno == ENOSPC) {
 		uint64_t file_time_ns = diff_timespec_ns(&file_t1, &file_t2);
+		double file_avg_speed;
 
 		if (saved_errno == 0)
 			assert(remaining_blocks == 0);
-		
-		if (file_time_ns > 0) {
-			double file_avg_speed = fw_get_speed(fw,
+
+		if (file_speed_samples >= 2) {
+			file_avg_speed = fw_get_speed(fw, file_tot_blocks,
+				file_tot_time_ns);
+			print_avg_min_max_samples("OK! ", "\n",
+				file_avg_speed, file_min_speed,	file_max_speed,
+				file_speed_samples);
+		} else if (file_time_ns > 0) {
+			file_avg_speed = fw_get_speed(fw,
 				total_file_blocks - remaining_blocks,
 				file_time_ns);
 			const char *unit = adjust_unit(&file_avg_speed);

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -181,11 +181,14 @@ static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 {
 	const unsigned int block_size = fw_get_block_size(fw);
 	const unsigned int block_order = fw_get_block_order(fw);
-	uint64_t remaining_blocks = 1ULL << (GIGABYTE_ORDER - block_order);
+	const uint64_t total_file_blocks =
+		1ULL << (GIGABYTE_ORDER - block_order);
+	uint64_t remaining_blocks = total_file_blocks;
 	char *full_fn;
 	const char *filename;
 	int fd, saved_errno;
 	uint64_t offset;
+	struct timespec file_t1, file_t2;
 
 	assert(GIGABYTE_ORDER >= block_order);
 
@@ -208,6 +211,7 @@ static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 	/* Write content. */
 	saved_errno = 0;
 	offset = number << GIGABYTE_ORDER;
+	assert(!clock_gettime(CLOCK_MONOTONIC, &file_t1));
 	start_measurement(fw);
 	while (remaining_blocks > 0) {
 		size_t bytes_written;
@@ -238,13 +242,26 @@ static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 			break;
 	}
 	end_measurement(fw);
+	assert(!clock_gettime(CLOCK_MONOTONIC, &file_t2));
 	close(fd);
 	free(full_fn);
 
 	if (saved_errno == 0 || saved_errno == ENOSPC) {
+		uint64_t file_time_ns = diff_timespec_ns(&file_t1, &file_t2);
+
 		if (saved_errno == 0)
 			assert(remaining_blocks == 0);
-		printf("OK!\n");
+		
+		if (file_time_ns > 0) {
+			double file_avg_speed = fw_get_speed(fw,
+				total_file_blocks - remaining_blocks,
+				file_time_ns);
+			const char *unit = adjust_unit(&file_avg_speed);
+			printf("OK! Avg: %.2f %s/s\n",
+				file_avg_speed, unit);
+		} else {
+			printf("OK!\n");
+		}
 		return saved_errno == ENOSPC;
 	}
 

--- a/src/f3write.c
+++ b/src/f3write.c
@@ -259,7 +259,7 @@ static int create_and_fill_file(struct flow *fw, struct dynamic_buffer *dbuf,
 		if (saved_errno != 0)
 			break;
 	}
-	end_measurement(fw);
+	end_measurement(fw, true);
 	assert(!clock_gettime(CLOCK_MONOTONIC, &file_t2));
 	close(fd);
 	free(full_fn);

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -457,13 +457,19 @@ void measure(struct flow *fw, uint64_t processed_blocks,
 	__start_measurement(fw);
 }
 
-void end_measurement(struct flow *fw)
+void end_measurement(struct flow *fw, bool measurement_boundary)
 {
 	if (fw->processed_blocks > 0) {
-		/* Track progress in between files. */
+		/* Track progress in between measurement boundaries. */
 		struct timespec t2;
 		assert(!clock_gettime(CLOCK_MONOTONIC, &t2));
 		fw->acc_delay_ns += diff_timespec_ns(&fw->t1, &t2);
+		if (measurement_boundary) {
+			fw->measured_blocks += fw->processed_blocks;
+			fw->measured_time_ns += fw->acc_delay_ns;
+			fw->processed_blocks = 0;
+			fw->acc_delay_ns = 0;
+		}
 	}
 	clear_progress(fw); /* Erase progress information. */
 }

--- a/src/libflow.c
+++ b/src/libflow.c
@@ -286,15 +286,19 @@ static void update_rem_chunk_blocks(struct flow *fw, double inst_speed)
 	fw->rem_chunk_speed = inst_speed;
 }
 
-void measure(struct flow *fw, uint64_t processed_blocks)
+void measure(struct flow *fw, uint64_t processed_blocks,
+	struct fw_measurement *m)
 {
 	struct timespec t2;
 	uint64_t delay_ns;
 	double bytes_g, inst_speed;
 
 	fw->processed_blocks += processed_blocks;
-	if (fw->processed_blocks < fw->blocks_per_delay)
+	if (fw->processed_blocks < fw->blocks_per_delay) {
+		if (m != NULL)
+			m->valid = false;
 		return;
+	}
 	assert(fw->processed_blocks == fw->blocks_per_delay);
 
 	assert(!clock_gettime(CLOCK_MONOTONIC, &t2));
@@ -368,6 +372,11 @@ void measure(struct flow *fw, uint64_t processed_blocks)
 	/* Update average. */
 	fw->measured_blocks += fw->processed_blocks;
 	fw->measured_time_ns += delay_ns;
+	if (m != NULL) {
+		m->valid = true;
+		m->blocks = fw->processed_blocks;
+		m->time_ns = delay_ns;
+	}
 	/* Reset accumulators. */
 	fw->processed_blocks = 0;
 	fw->acc_delay_ns = 0;

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -120,7 +120,7 @@ void start_measurement(struct flow *fw);
 void measure(struct flow *fw, uint64_t processed_blocks,
 	struct fw_measurement *m);
 void clear_progress(struct flow *fw);
-void end_measurement(struct flow *fw);
+void end_measurement(struct flow *fw, bool measurement_boundary);
 
 void print_avg_seq_speed(const struct flow *fw, const char *speed_type,
 	bool use_sectors);

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -110,8 +110,15 @@ static inline double fw_get_speed(const struct flow *fw, uint64_t blocks,
 
 uint64_t get_rem_chunk_blocks(const struct flow *fw);
 
+struct fw_measurement {
+	bool		valid;
+	uint64_t	blocks;
+	uint64_t	time_ns;
+};
+
 void start_measurement(struct flow *fw);
-void measure(struct flow *fw, uint64_t processed_blocks);
+void measure(struct flow *fw, uint64_t processed_blocks,
+	struct fw_measurement *m);
 void clear_progress(struct flow *fw);
 void end_measurement(struct flow *fw);
 

--- a/src/libflow.h
+++ b/src/libflow.h
@@ -101,6 +101,13 @@ static inline void fw_get_measurements(const struct flow *fw,
 	*time_ns = fw->measured_time_ns + fw->acc_delay_ns;
 }
 
+/* Return speed in bytes per second. */
+static inline double fw_get_speed(const struct flow *fw, uint64_t blocks,
+	uint64_t time_ns)
+{
+	return (blocks << fw->block_order) * 1000000000.0 / time_ns;
+}
+
 uint64_t get_rem_chunk_blocks(const struct flow *fw);
 
 void start_measurement(struct flow *fw);

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -77,7 +77,7 @@ static int write_random_blocks(struct device *dev, const uint64_t pos[],
 		if (_write_blocks(dev, buffer, pos[i], pos[i], &rwi->randw_fw,
 				cb, indent))
 			return true;
-		measure(&rwi->randw_fw, 1);
+		measure(&rwi->randw_fw, 1, NULL);
 	}
 	end_measurement(&rwi->randw_fw);
 	return false;
@@ -125,7 +125,7 @@ static int write_blocks(struct device *dev,
 				&rwi->seqw_fw, cb, indent))
 			return true;
 
-		measure(&rwi->seqw_fw, blocks_to_write);
+		measure(&rwi->seqw_fw, blocks_to_write, NULL);
 		first_pos = next_pos;
 	}
 	end_measurement(&rwi->seqw_fw);
@@ -225,7 +225,7 @@ static int find_first_x_block(struct device *dev,
 			return true;
 		bs = validate_buffer_with_block(probe_blk, block_order,
 			x_blocks[i].expected_offset, &found_offset, rwi->salt);
-		measure(&rwi->randr_fw, 1);
+		measure(&rwi->randr_fw, 1, NULL);
 
 		if (in_bs_set(bs_set, bs)) {
 			/* Found the first x_block. */

--- a/src/libprobe.c
+++ b/src/libprobe.c
@@ -79,7 +79,7 @@ static int write_random_blocks(struct device *dev, const uint64_t pos[],
 			return true;
 		measure(&rwi->randw_fw, 1, NULL);
 	}
-	end_measurement(&rwi->randw_fw);
+	end_measurement(&rwi->randw_fw, false);
 	return false;
 }
 
@@ -128,7 +128,7 @@ static int write_blocks(struct device *dev,
 		measure(&rwi->seqw_fw, blocks_to_write, NULL);
 		first_pos = next_pos;
 	}
-	end_measurement(&rwi->seqw_fw);
+	end_measurement(&rwi->seqw_fw, false);
 	return false;
 }
 
@@ -231,11 +231,11 @@ static int find_first_x_block(struct device *dev,
 			/* Found the first x_block. */
 			*pfirst_x_block_idx = i;
 			*pstate = bs;
-			end_measurement(&rwi->randr_fw);
+			end_measurement(&rwi->randr_fw, false);
 			return false;
 		}
 	}
-	end_measurement(&rwi->randr_fw);
+	end_measurement(&rwi->randr_fw, false);
 
 not_found:
 	*pfirst_x_block_idx = n_blocks;

--- a/src/libutils.c
+++ b/src/libutils.c
@@ -343,6 +343,18 @@ void print_stats(const struct block_stats *stats, unsigned int block_order,
 	print_stat("\t     Overwritten:", stats->overwritten, block_order, unit_name);
 }
 
+void print_avg_min_max_samples(const char *prefix, const char *suffix,
+	double avg_speed, double min_speed, double max_speed, uint64_t samples)
+{
+	const char *avg_unit = adjust_unit(&avg_speed);
+	const char *min_unit = adjust_unit(&min_speed);
+	const char *max_unit = adjust_unit(&max_speed);
+
+	printf("%sAvg: %.2f %s/s\n\tMin: %.2f %s/s, Max: %.2f %s/s, %" PRIu64 " samples%s",
+		prefix, avg_speed, avg_unit, min_speed, min_unit,
+		max_speed, max_unit, samples, suffix);
+}
+
 void report_io_speed(unsigned int indent, progress_cb cb, const char *prefix,
 	uint64_t blocks, const char *block_unit, uint64_t time_ns,
 	unsigned int block_order)

--- a/src/libutils.h
+++ b/src/libutils.h
@@ -136,6 +136,9 @@ static inline uint64_t diff_timespec_ns(const struct timespec *t1,
 void print_stats(const struct block_stats *stats, unsigned int block_order,
 	const char *unit_name);
 
+void print_avg_min_max_samples(const char *prefix, const char *suffix,
+	double avg_speed, double min_speed, double max_speed, uint64_t samples);
+
 void report_io_speed(unsigned int indent, progress_cb cb, const char *prefix,
 	uint64_t blocks, const char *block_unit, uint64_t time_ns,
 	unsigned int block_order);


### PR DESCRIPTION
This pull request introduces per-file I/O speed reporting to `f3write` and `f3read` without disrupting `libflow`'s throttling logic.

**Problem:**
Previously, `f3write` and `f3read` reported a cumulative average speed at the start of each file. Because `libflow` groups blocks dynamically, measurements often crossed file boundaries — especially on drives exceeding 1GB/s where a 1GB file finishes in a fraction of a second. This architecture meant that per-file speed and internal performance metrics, such as min and max speeds, were not available.

**Solution:**
This pull request introduces three complementary changes to separate statistics reporting from flow control:
1. **Macro-Level Timing:** Wraps the file-processing loops in `f3write` and `f3read` with `clock_gettime()` to accurately measure the wall-clock time spent on each file independently of `libflow`, providing a per-file average speed.
2. **Instantaneous Min/Max Tracking:** Exposes the instantaneous speed (`inst_speed`) from `libflow`'s `measure()` function, allowing `f3write` and `f3read` to track the minimum and maximum speeds observed during the processing of each file.
3. **Clean Measurement Boundaries:** Introduces parameter `bool measurement_boundary` to `end_measurement()` in `libflow` to commit any leftover block progress and time measurements at the end of a file without invoking the flow state machine, ensuring measurement data does not bleed across file boundaries.

This pull request closes #134 and closes #251.